### PR TITLE
Adiciona listener com exemplo de captura de adição/remoção de roles

### DIFF
--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -1,19 +1,32 @@
-import { Client, GatewayIntentBits, Partials } from "discord.js";
-import { monitorEvents, monitorEventUserAdd, monitorStatusUpdateEvent, monitorCreateEvents, monitorEventUserRemove, monitorStatusEvent } from "./events.js";
+import { Client, Events, GatewayIntentBits, Partials } from "discord.js";
+import {
+  monitorEvents,
+  monitorEventUserAdd,
+  monitorStatusUpdateEvent,
+  monitorCreateEvents,
+  monitorEventUserRemove,
+  monitorStatusEvent,
+} from "./events.js";
 import { authUser, loginUser } from "./init";
 import { voiceStateUpdate } from "./monitor";
 import { createReport, executeReport } from "./report";
-import { monitorReaction, monitorContentType, monitorMessages } from "./message.js";
+import {
+  monitorReaction,
+  monitorContentType,
+  monitorMessages,
+} from "./message.js";
+import { checkForRoleUpdate } from "./member.js";
 
 const client = new Client({
   intents: [
-    GatewayIntentBits.Guilds,
-    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.DirectMessages,
+    GatewayIntentBits.GuildMembers,
     GatewayIntentBits.GuildMessageReactions,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildScheduledEvents,
     GatewayIntentBits.GuildVoiceStates,
     GatewayIntentBits.MessageContent,
-    GatewayIntentBits.DirectMessages,
-    GatewayIntentBits.GuildScheduledEvents
   ],
   partials: [
     Partials.Message, // Permite rastrear reações em mensagens não armazenadas em cache
@@ -28,21 +41,24 @@ client.on("ready", async () => {
 client.on("messageCreate", authUser);
 client.on("messageCreate", loginUser);
 client.on("guildScheduledEventCreate", monitorEvents);
-client.on('guildScheduledEventUserAdd', monitorEventUserAdd);
-client.on('guildScheduledEventUserRemove', monitorEventUserRemove);
-client.on('guildScheduledEventUpdate', monitorStatusEvent);
+client.on("guildScheduledEventUserAdd", monitorEventUserAdd);
+client.on("guildScheduledEventUserRemove", monitorEventUserRemove);
+client.on("guildScheduledEventUpdate", monitorStatusEvent);
 client.on("GuildScheduledEventCreateOptions", monitorCreateEvents);
 client.on("guildScheduledEventUpdate", monitorStatusUpdateEvent);
 client.on("messageReactionAdd", monitorReaction);
-client.on("messageCreate", monitorContentType)
+client.on("messageCreate", monitorContentType);
 
 client.on("messageCreate", monitorMessages);
 client.on("voiceStateUpdate", voiceStateUpdate);
 
-// Comando de Relatório
-client['command'] = new Map(); // <--- metodo nao existente no client do discord. Referencia: https://dev.to/fellipeutaka/creating-your-first-discord-bot-using-typescript-1eh6
+client.on(Events.GuildMemberUpdate, checkForRoleUpdate);
 
-client['command'].set("report", { // <--- metodo nao existente no client do discord. Referencia: https://dev.to/fellipeutaka/creating-your-first-discord-bot-using-typescript-1eh6
+// Comando de Relatório
+client["command"] = new Map(); // <--- metodo nao existente no client do discord. Referencia: https://dev.to/fellipeutaka/creating-your-first-discord-bot-using-typescript-1eh6
+
+client["command"].set("report", {
+  // <--- metodo nao existente no client do discord. Referencia: https://dev.to/fellipeutaka/creating-your-first-discord-bot-using-typescript-1eh6
   execute: executeReport,
 });
 

--- a/src/bot/member.ts
+++ b/src/bot/member.ts
@@ -1,0 +1,23 @@
+import { ClientEvents, Events } from "discord.js";
+
+type GuildMemberUpdateListener = (...args: ClientEvents[typeof Events.GuildMemberUpdate]) => void;
+
+export const checkForRoleUpdate: GuildMemberUpdateListener = (oldMember, newMember) => {
+  const oldRoleIds = oldMember.roles.cache.map((role) => role.id);
+  const newRoleIds = newMember.roles.cache.map((role) => role.id);
+
+  const addedRoles = newRoleIds.filter((role) => !oldRoleIds.includes(role));
+  const removedRoles = oldRoleIds.filter((role) => !newRoleIds.includes(role));
+
+  const latestDisplayName = newMember.user.displayName;
+
+  if (addedRoles.length > 0) {
+    console.log(`Cargos adicionados (${latestDisplayName}):`);
+    console.log(`>>> ${addedRoles}`);
+  }
+
+  if (removedRoles.length > 0) {
+    console.log(`Cargos removidos (${latestDisplayName}):`);
+    console.log(`>>> ${removedRoles}`);
+  }
+};


### PR DESCRIPTION
## Descrição
Adiciona um exemplo demonstrando como é possível capturar a adição/remoção de roles de usuários de um servidor.

Na história do spike, também há o requisito de verificar há quanto tempo um usuário está no servidor, mas isso já está exemplificado na `executeReport` (`src/bot/report.ts`), então não adicionei nada nesse sentido.

## Link da tarefa
[CPDD-77](https://www.notion.so/cpdd/Estudos-Spike-Monitoramento-do-Usu-rio-14fc5f6d25f8803faec5f6015a2f3d6e?pvs=4)

## Tipo de mudança
- [ ] Bugfix
- [X] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

## Como foi testado?
- Fazer a configuração de algum bot pessoal em algum servidor, configurar o projeto com esse bot
- No servidor em que o bot estiver ativo, adicionar/remover um _role_ de algum usuário
- Verificar que, no terminal rodando o bot, uma mensagem identificando o usuário e o(s) _role(s)_ alterado(s) é printada

## Checklist
- [ ] Código segue o padrão de estilo do projeto
- [ ] Testes unitários foram adicionados
- [ ] A documentação foi atualizada (se aplicável)
