### PR TITLE
CPDD-158: Adiciona path aliases e configs locais e em prod

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,0 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} **/
-module.exports = {
-  testEnvironment: "node",
-  transform: {
-    "^.+\.tsx?$": ["ts-jest",{}],
-  },
-  setupFilesAfterEnv: ['<rootDir>/src/tests/config/singleton.ts'],
-};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,17 @@
+import type { JestConfigWithTsJest } from "ts-jest";
+import { pathsToModuleNameMapper } from "ts-jest";
+import { compilerOptions } from "./tsconfig.json";
+
+const config: JestConfigWithTsJest = {
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.tsx?$": ["ts-jest", {}],
+  },
+  setupFilesAfterEnv: ["<rootDir>/src/tests/config/singleton.ts"],
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths || {}, {
+    prefix: "<rootDir>/src/",
+  }),
+  testPathIgnorePatterns: ["/node_modules/", "/dist/"],
+};
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,8 @@
         "prettier": "^3.5.3",
         "prisma-dbml-generator": "^0.12.0",
         "ts-jest": "^29.2.6",
+        "tsc-alias": "^1.8.16",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "^5.7",
         "typescript-eslint": "^8.18.1"
       }
@@ -2876,7 +2878,8 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -5349,6 +5352,42 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
@@ -6121,6 +6160,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/get-uri": {
@@ -7217,6 +7269,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8817,6 +8870,20 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
+    "node_modules/mylas": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
+      "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/raouldeheer"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -9656,6 +9723,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/plimit-lit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "queue-lit": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/pm2": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/pm2/-/pm2-5.4.3.tgz",
@@ -10039,6 +10119,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-lit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10379,6 +10469,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/resolve.exports": {
@@ -11623,28 +11723,51 @@
       "integrity": "sha512-pefrkcd4lmIVR0LA49Imjf9DYLK8vtWhqBPA3Ya1ir8xCW0O2yjL9dsCVvI7pCodLC5q7smNpEtDR2yVulQxOg==",
       "dev": true
     },
-    "node_modules/tsconfig-paths": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+    "node_modules/tsc-alias": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.16.tgz",
+      "integrity": "sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "get-tsconfig": "^4.10.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
       },
       "bin": {
-        "json5": "lib/cli.js"
+        "tsc-alias": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tsconfig-paths/node_modules/strip-bom": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "main": "dist/index.js",
   "type": "commonjs",
   "scripts": {
-    "build": "tsc",
-    "start": "tsc && node dist/index.js",
+    "build": "tsc && tsc-alias",
+    "start": "tsc && tsc-alias && node dist/index.js",
     "dev": "docker compose --profile dev up -d && npx prisma generate && npx prisma migrate dev && nodemon --exec ts-node ./src/index.ts",
+    "prod": "docker compose -f compose.yml --profile prod up -d --build",
     "worker": "tsc && pm2 start dist/index.js --no-daemon",
     "heroku-postbuild": "npm install pm2 --save",
     "db:migrate": "npx prisma migrate dev",
@@ -48,6 +49,8 @@
     "prettier": "^3.5.3",
     "prisma-dbml-generator": "^0.12.0",
     "ts-jest": "^29.2.6",
+    "tsc-alias": "^1.8.16",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7",
     "typescript-eslint": "^8.18.1"
   },

--- a/src/application/command/userCommand.ts
+++ b/src/application/command/userCommand.ts
@@ -1,20 +1,20 @@
 // orquestra os useCases command de user.
 
 import { Client, GuildMember, Message, PartialGuildMember } from "discord.js";
-import { IDiscordService } from "../../domain/interfaces/services/IDiscordService";
+import { IDiscordService } from "@services/IDiscordService";
 import {
   CreateUserInput,
   ICreateUser,
-} from "../../domain/interfaces/useCases/user/ICreateUser";
-import { IUpdateUser } from "../../domain/interfaces/useCases/user/IUpdateUser";
-import { UserStatus } from "../../domain/types/UserStatusEnum";
-import { ILoggerService } from "../../domain/interfaces/services/ILogger";
+} from "@interfaces/useCases/user/ICreateUser";
+import { IUpdateUser } from "@interfaces/useCases/user/IUpdateUser";
+import { UserStatus } from "@type/UserStatusEnum";
+import { ILoggerService } from "@services/ILogger";
 import {
   LoggerContext,
   LoggerContextEntity,
   LoggerContextStatus,
-} from "../../domain/types/LoggerContextEnum";
-import { IUserCommand } from "../../domain/interfaces/commands/IUserCommand";
+} from "@type/LoggerContextEnum";
+import { IUserCommand } from "@interfaces/commands/IUserCommand";
 
 export class UserCommand implements IUserCommand {
   constructor(
@@ -26,7 +26,7 @@ export class UserCommand implements IUserCommand {
     >,
     private readonly logger: ILoggerService,
     private readonly createUser: ICreateUser,
-    private readonly updateUser: IUpdateUser
+    private readonly updateUser: IUpdateUser,
   ) {
     this.executeNewUser();
     this.executeAllUsers();
@@ -42,7 +42,7 @@ export class UserCommand implements IUserCommand {
         LoggerContextStatus.ERROR,
         LoggerContext.COMMAND,
         LoggerContextEntity.USER,
-        `executeNewUser | ${error.message}`
+        `executeNewUser | ${error.message}`,
       );
     }
   }
@@ -55,7 +55,7 @@ export class UserCommand implements IUserCommand {
         const guild = await this.discordService.client.guilds.fetch(guildId);
         const members = await guild.members.fetch();
         this.createUser.executeMany(
-          members.map((member) => UserCommand.toUserEntity(member))
+          members.map((member) => UserCommand.toUserEntity(member)),
         );
       });
     } catch (error) {
@@ -63,7 +63,7 @@ export class UserCommand implements IUserCommand {
         LoggerContextStatus.ERROR,
         LoggerContext.COMMAND,
         LoggerContextEntity.USER,
-        `executeAllUsers | ${error.message}`
+        `executeAllUsers | ${error.message}`,
       );
     }
   }
@@ -77,7 +77,7 @@ export class UserCommand implements IUserCommand {
         LoggerContextStatus.ERROR,
         LoggerContext.COMMAND,
         LoggerContextEntity.USER,
-        `executeUserLeave | ${error.message}`
+        `executeUserLeave | ${error.message}`,
       );
     }
   }

--- a/src/application/services/Logger.ts
+++ b/src/application/services/Logger.ts
@@ -1,17 +1,17 @@
-import { LogEvent } from "../../domain/entities/LogEvent";
-import { ILoggerService } from "../../domain/interfaces/services/ILogger";
+import { LogEvent } from "@entities/LogEvent";
+import { ILoggerService } from "@services/ILogger";
 import {
   LoggerContextStatus,
   LoggerContext,
   LoggerContextEntity,
-} from "../../domain/types/LoggerContextEnum";
+} from "@type/LoggerContextEnum";
 
 export class Logger implements ILoggerService {
   logToConsole(
     status: LoggerContextStatus,
     context: LoggerContext,
     entity: LoggerContextEntity,
-    message: string
+    message: string,
   ): void {
     const eventId = new Date().getTime();
     const event = new LogEvent(
@@ -20,17 +20,21 @@ export class Logger implements ILoggerService {
       context,
       entity,
       message,
-      new Date()
+      new Date(),
     );
     if (event.status === LoggerContextStatus.ERROR)
       console.error(JSON.stringify(event));
     else console.log(JSON.stringify(event));
   }
   logToDatabase(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     status: LoggerContextStatus,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     context: LoggerContext,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     entity: LoggerContextEntity,
-    message: string
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    message: string,
   ): void {
     throw new Error("Method not implemented.");
   }

--- a/src/contexts/app.context.ts
+++ b/src/contexts/app.context.ts
@@ -1,14 +1,14 @@
 import { initializeDatabase } from "./database.context";
 import { initializeUserUseCases } from "./useUserCases.context";
 import { initializeDiscord } from "./discord.context";
-import { UserCommand } from "../application/command/userCommand";
-import { Logger } from "../application/services/Logger";
+import { UserCommand } from "@application/command/userCommand";
+import { Logger } from "@application/services/Logger";
 import {
   LoggerContextStatus,
   LoggerContext,
   LoggerContextEntity,
-} from "../domain/types/LoggerContextEnum";
-import { ErrorMessages } from "../domain/types/ErrorMessages";
+} from "@type/LoggerContextEnum";
+import { ErrorMessages } from "@type/ErrorMessages";
 
 export function initializeApp() {
   // Aqui vao as dependencias externas

--- a/src/contexts/database.context.ts
+++ b/src/contexts/database.context.ts
@@ -1,8 +1,8 @@
-import { PrismaService } from "../infrastructure/persistence/prisma/prismaService";
-import { UserRepository } from "../infrastructure/persistence/repositories/UserRepository";
-import { IUserRepository } from "../domain/interfaces/repositories/IUserRepository";
+import { PrismaService } from "@infra/persistence/prisma/prismaService";
+import { UserRepository } from "@infra/repositories/UserRepository";
+import { IUserRepository } from "@repositories/IUserRepository";
 import { PrismaClient } from "@prisma/client";
-import { ILoggerService } from "../domain/interfaces/services/ILogger";
+import { ILoggerService } from "@services/ILogger";
 
 /**
  * Inicializa e configura o banco de dados.
@@ -16,7 +16,7 @@ import { ILoggerService } from "../domain/interfaces/services/ILogger";
 
 export function initializeDatabase(
   logger: ILoggerService,
-  prismaService?: PrismaService
+  prismaService?: PrismaService,
 ): {
   userRepository: IUserRepository;
 } {
@@ -25,7 +25,7 @@ export function initializeDatabase(
 
   const userRepository = new UserRepository(
     prismaService ?? newPrismaService,
-    logger
+    logger,
   );
   return { userRepository };
 }

--- a/src/contexts/discord.context.ts
+++ b/src/contexts/discord.context.ts
@@ -6,8 +6,8 @@ import {
   Message,
   PartialGuildMember,
 } from "discord.js";
-import { DiscordService } from "../infrastructure/discord/DiscordService";
-import { IDiscordService } from "../domain/interfaces/services/IDiscordService";
+import { DiscordService } from "@discord/DiscordService";
+import { IDiscordService } from "@services/IDiscordService";
 
 // Mapea os eventos do discord para as intents que precisam ser registradas no client.
 const EVENT_INTENTS_MAP: Partial<Record<Events, GatewayIntentBits[]>> = {

--- a/src/contexts/useUserCases.context.ts
+++ b/src/contexts/useUserCases.context.ts
@@ -1,12 +1,12 @@
-import { IUserRepository } from "../domain/interfaces/repositories/IUserRepository";
-import { ILoggerService } from "../domain/interfaces/services/ILogger";
-import { CreateUser } from "../domain/useCases/user/CreateUser";
-import { FindUser } from "../domain/useCases/user/FindUser";
-import { UpdateUser } from "../domain/useCases/user/UpdateUser";
+import { IUserRepository } from "@repositories/IUserRepository";
+import { ILoggerService } from "@services/ILogger";
+import { CreateUser } from "@useCases/user/CreateUser";
+import { FindUser } from "@useCases/user/FindUser";
+import { UpdateUser } from "@useCases/user/UpdateUser";
 
 export function initializeUserUseCases(
   userRepository: IUserRepository,
-  logger: ILoggerService
+  logger: ILoggerService,
 ) {
   const createUserCase = new CreateUser(userRepository, logger);
   const findUserCase = new FindUser(userRepository, logger);

--- a/src/domain/entities/LogEvent.ts
+++ b/src/domain/entities/LogEvent.ts
@@ -2,7 +2,7 @@ import {
   LoggerContext,
   LoggerContextEntity,
   LoggerContextStatus,
-} from "../types/LoggerContextEnum";
+} from "@type/LoggerContextEnum";
 
 export class LogEvent {
   constructor(
@@ -11,6 +11,6 @@ export class LogEvent {
     public readonly context: LoggerContext,
     public readonly entity: LoggerContextEntity,
     public readonly message: string,
-    public readonly createdAt: Date
+    public readonly createdAt: Date,
   ) {}
 }

--- a/src/domain/entities/User.ts
+++ b/src/domain/entities/User.ts
@@ -1,4 +1,4 @@
-import { UserStatus } from "../types/UserStatusEnum";
+import { UserStatus } from "@type/UserStatusEnum";
 
 export class UserEntity {
   // Deveria ser User, mas o discord ja tem User, é MUITO chato ficar importando a coisa errada toda hora.
@@ -14,6 +14,6 @@ export class UserEntity {
     public readonly createAt?: Date | null,
     public readonly updateAt?: Date | null,
     public readonly lastActive?: Date | null,
-    public readonly email?: string | null
+    public readonly email?: string | null,
   ) {}
 }

--- a/src/domain/interfaces/repositories/ILogger.ts
+++ b/src/domain/interfaces/repositories/ILogger.ts
@@ -1,4 +1,4 @@
-import { LogEvent } from "../../entities/LogEvent";
+import { LogEvent } from "@entities/LogEvent";
 
 export interface ILoggerRepository {
   create(user: Omit<LogEvent, "id">): Promise<LogEvent>;

--- a/src/domain/interfaces/repositories/IUserRepository.ts
+++ b/src/domain/interfaces/repositories/IUserRepository.ts
@@ -1,4 +1,4 @@
-import { UserEntity } from "../../entities/User";
+import { UserEntity } from "@entities/User";
 
 export interface IUserRepository {
   create(user: Omit<UserEntity, "id">): Promise<UserEntity>;
@@ -6,7 +6,7 @@ export interface IUserRepository {
   findById(id: number, includeInactive?: boolean): Promise<UserEntity | null>;
   findByDiscordId(
     id: string,
-    includeInactive?: boolean
+    includeInactive?: boolean,
   ): Promise<UserEntity | null>;
   listAll(limit?: number, includeInactive?: boolean): Promise<UserEntity[]>;
   updateById(id: number, user: Partial<UserEntity>): Promise<UserEntity | null>;

--- a/src/domain/interfaces/services/ILogger.ts
+++ b/src/domain/interfaces/services/ILogger.ts
@@ -2,20 +2,20 @@ import {
   LoggerContext,
   LoggerContextEntity,
   LoggerContextStatus,
-} from "../../types/LoggerContextEnum";
+} from "@type/LoggerContextEnum";
 
 export interface ILoggerService {
   logToConsole(
     status: LoggerContextStatus,
     context: LoggerContext,
     entity: LoggerContextEntity,
-    message: string
+    message: string,
   ): void;
 
   logToDatabase(
     status: LoggerContextStatus,
     context: LoggerContext,
     entity: LoggerContextEntity,
-    message: string
+    message: string,
   ): void;
 }

--- a/src/domain/interfaces/useCases/user/ICreateUser.ts
+++ b/src/domain/interfaces/useCases/user/ICreateUser.ts
@@ -1,6 +1,6 @@
-import { CreateManyUserOutputDto } from "../../../dtos/CreateManyUserOutputDto";
-import { GenericOutputDto } from "../../../dtos/GenericOutputDto";
-import { UserEntity } from "../../../entities/User";
+import { CreateManyUserOutputDto } from "@dtos/CreateManyUserOutputDto";
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+import { UserEntity } from "@entities/User";
 
 //Input DTO para criar um novo usuario
 export type CreateUserInput = Omit<UserEntity, "id">;
@@ -8,6 +8,6 @@ export type CreateUserInput = Omit<UserEntity, "id">;
 export interface ICreateUser {
   execute(User: CreateUserInput): Promise<GenericOutputDto<UserEntity>>;
   executeMany(
-    users: CreateUserInput[]
+    users: CreateUserInput[],
   ): Promise<GenericOutputDto<CreateManyUserOutputDto>>;
 }

--- a/src/domain/interfaces/useCases/user/IDeleteUser.ts
+++ b/src/domain/interfaces/useCases/user/IDeleteUser.ts
@@ -1,5 +1,5 @@
-import { GenericOutputDto } from "../../../dtos/GenericOutputDto";
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
 
 export interface IDeleteUser {
-  execute(id: number | string): Promise<GenericOutputDto<Boolean>>;
+  execute(id: number | string): Promise<GenericOutputDto<boolean>>;
 }

--- a/src/domain/interfaces/useCases/user/IFindUser.ts
+++ b/src/domain/interfaces/useCases/user/IFindUser.ts
@@ -1,5 +1,5 @@
-import { GenericOutputDto } from "../../../dtos/GenericOutputDto";
-import { UserEntity } from "../../../entities/User";
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+import { UserEntity } from "@entities/User";
 
 export interface IFindUser {
   execute(id: number | string): Promise<GenericOutputDto<UserEntity>>;

--- a/src/domain/interfaces/useCases/user/IUpdateUser.ts
+++ b/src/domain/interfaces/useCases/user/IUpdateUser.ts
@@ -1,13 +1,13 @@
-import { GenericOutputDto } from "../../../dtos/GenericOutputDto";
-import { UserEntity } from "../../../entities/User";
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+import { UserEntity } from "@entities/User";
 
 export interface IUpdateUser {
   execute(
     id: number | string,
-    data: Partial<UserEntity>
+    data: Partial<UserEntity>,
   ): Promise<GenericOutputDto<UserEntity>>;
 
   executeInvertUserStatus(
-    id: number | string
+    id: number | string,
   ): Promise<GenericOutputDto<UserEntity>>;
 }

--- a/src/domain/useCases/user/CreateUser.ts
+++ b/src/domain/useCases/user/CreateUser.ts
@@ -1,25 +1,25 @@
-import { CreateManyUserOutputDto } from "../../dtos/CreateManyUserOutputDto";
-import { GenericOutputDto } from "../../dtos/GenericOutputDto";
-import { UserEntity } from "../../entities/User";
-import { IUserRepository } from "../../interfaces/repositories/IUserRepository";
-import { ILoggerService } from "../../interfaces/services/ILogger";
+import { CreateManyUserOutputDto } from "@dtos/CreateManyUserOutputDto";
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+import { UserEntity } from "@entities/User";
+import { IUserRepository } from "@repositories/IUserRepository";
+import { ILoggerService } from "@services/ILogger";
 import {
   CreateUserInput,
   ICreateUser,
-} from "../../interfaces/useCases/user/ICreateUser";
-import { ErrorMessages } from "../../types/ErrorMessages";
+} from "@interfaces/useCases/user/ICreateUser";
+import { ErrorMessages } from "@type/ErrorMessages";
 import {
   LoggerContextStatus,
   LoggerContext,
   LoggerContextEntity,
-} from "../../types/LoggerContextEnum";
-import { CommonMessages } from "../../types/CommonMessages";
-import { UserStatus } from "../../types/UserStatusEnum";
+} from "@type/LoggerContextEnum";
+import { CommonMessages } from "@type/CommonMessages";
+import { UserStatus } from "@type/UserStatusEnum";
 
 export class CreateUser implements ICreateUser {
   constructor(
     private readonly userRepository: IUserRepository,
-    private readonly logger: ILoggerService
+    private readonly logger: ILoggerService,
   ) {}
 
   async execute(input: CreateUserInput): Promise<GenericOutputDto<UserEntity>> {
@@ -35,7 +35,7 @@ export class CreateUser implements ICreateUser {
       // Check if user already exists
       const existingUser = await this.userRepository.findByDiscordId(
         input.discordId,
-        true
+        true,
       );
       if (existingUser) {
         if (existingUser.status === UserStatus.INACTIVE) {
@@ -43,7 +43,7 @@ export class CreateUser implements ICreateUser {
             existingUser.id,
             {
               status: UserStatus.ACTIVE,
-            }
+            },
           );
           return {
             data: reactivatedUser,
@@ -73,7 +73,7 @@ export class CreateUser implements ICreateUser {
         LoggerContextStatus.ERROR,
         LoggerContext.USECASE,
         LoggerContextEntity.USER,
-        `createUser.execute | ${error.message}`
+        `createUser.execute | ${error.message}`,
       );
       return {
         data: null,
@@ -85,11 +85,11 @@ export class CreateUser implements ICreateUser {
   }
 
   async executeMany(
-    users: CreateUserInput[]
+    users: CreateUserInput[],
   ): Promise<GenericOutputDto<CreateManyUserOutputDto>> {
     try {
       const created = await this.userRepository.createMany(
-        users.filter((user) => !user.bot)
+        users.filter((user) => !user.bot),
       );
       return {
         data: {
@@ -103,7 +103,7 @@ export class CreateUser implements ICreateUser {
         LoggerContextStatus.ERROR,
         LoggerContext.USECASE,
         LoggerContextEntity.USER,
-        `CreateUser.executeMany | ${error.message}`
+        `CreateUser.executeMany | ${error.message}`,
       );
       return {
         data: null,

--- a/src/domain/useCases/user/DeleteUser.ts
+++ b/src/domain/useCases/user/DeleteUser.ts
@@ -1,15 +1,15 @@
 // TODO: Delete fisico em cascata
 
-import { GenericOutputDto } from "../../dtos/GenericOutputDto";
-import { UserEntity } from "../../entities/User";
-import { IUserRepository } from "../../interfaces/repositories/IUserRepository";
-import { IDeleteUser } from "../../interfaces/useCases/user/IDeleteUser";
-import { ErrorMessages } from "../../types/ErrorMessages";
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+import { UserEntity } from "@entities/User";
+import { IUserRepository } from "@repositories/IUserRepository";
+import { IDeleteUser } from "@interfaces/useCases/user/IDeleteUser";
+import { ErrorMessages } from "@type/ErrorMessages";
 
 export class DeleteUser implements IDeleteUser {
   constructor(private readonly userRepository: IUserRepository) {}
 
-  async execute(id: number | string): Promise<GenericOutputDto<Boolean>> {
+  async execute(id: number | string): Promise<GenericOutputDto<boolean>> {
     try {
       let user: UserEntity;
 

--- a/src/domain/useCases/user/FindUser.ts
+++ b/src/domain/useCases/user/FindUser.ts
@@ -1,19 +1,19 @@
-import { GenericOutputDto } from "../../dtos/GenericOutputDto";
-import { UserEntity } from "../../entities/User";
-import { IUserRepository } from "../../interfaces/repositories/IUserRepository";
-import { ILoggerService } from "../../interfaces/services/ILogger";
-import { IFindUser } from "../../interfaces/useCases/user/IFindUser";
-import { ErrorMessages } from "../../types/ErrorMessages";
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+import { UserEntity } from "@entities/User";
+import { IUserRepository } from "@repositories/IUserRepository";
+import { ILoggerService } from "@services/ILogger";
+import { IFindUser } from "@interfaces/useCases/user/IFindUser";
+import { ErrorMessages } from "@type/ErrorMessages";
 import {
   LoggerContext,
   LoggerContextEntity,
   LoggerContextStatus,
-} from "../../types/LoggerContextEnum";
+} from "@type/LoggerContextEnum";
 
 export class FindUser implements IFindUser {
   constructor(
     private readonly userRepository: IUserRepository,
-    private readonly logger: ILoggerService
+    private readonly logger: ILoggerService,
   ) {}
 
   async execute(id: number | string): Promise<GenericOutputDto<UserEntity>> {
@@ -43,7 +43,7 @@ export class FindUser implements IFindUser {
         LoggerContextStatus.ERROR,
         LoggerContext.USECASE,
         LoggerContextEntity.USER,
-        `FindUser.execute | ${error.message}`
+        `FindUser.execute | ${error.message}`,
       );
       return {
         data: null,
@@ -55,7 +55,7 @@ export class FindUser implements IFindUser {
   }
 
   async executeFindAll(
-    limit?: number
+    limit?: number,
   ): Promise<GenericOutputDto<UserEntity[]>> {
     try {
       const users = await this.userRepository.listAll(limit);
@@ -68,7 +68,7 @@ export class FindUser implements IFindUser {
         LoggerContextStatus.ERROR,
         LoggerContext.USECASE,
         LoggerContextEntity.USER,
-        `executeFindAll.execute | ${error.message}`
+        `executeFindAll.execute | ${error.message}`,
       );
       return {
         data: null,

--- a/src/domain/useCases/user/UpdateUser.ts
+++ b/src/domain/useCases/user/UpdateUser.ts
@@ -1,24 +1,24 @@
-import { GenericOutputDto } from "../../dtos/GenericOutputDto";
-import { UserEntity } from "../../entities/User";
-import { IUserRepository } from "../../interfaces/repositories/IUserRepository";
-import { ILoggerService } from "../../interfaces/services/ILogger";
-import { IUpdateUser } from "../../interfaces/useCases/user/IUpdateUser";
-import { ErrorMessages } from "../../types/ErrorMessages";
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+import { UserEntity } from "@entities/User";
+import { IUserRepository } from "@repositories/IUserRepository";
+import { ILoggerService } from "@services/ILogger";
+import { IUpdateUser } from "@interfaces/useCases/user/IUpdateUser";
+import { ErrorMessages } from "@type/ErrorMessages";
 import {
   LoggerContextStatus,
   LoggerContext,
   LoggerContextEntity,
-} from "../../types/LoggerContextEnum";
-import { UserStatus } from "../../types/UserStatusEnum";
+} from "@type/LoggerContextEnum";
+import { UserStatus } from "@type/UserStatusEnum";
 
 export class UpdateUser implements IUpdateUser {
   constructor(
     private readonly userRepository: IUserRepository,
-    private readonly logger: ILoggerService
+    private readonly logger: ILoggerService,
   ) {}
   async execute(
     id: number | string,
-    data: Partial<UserEntity>
+    data: Partial<UserEntity>,
   ): Promise<GenericOutputDto<UserEntity>> {
     try {
       let user: UserEntity;
@@ -47,7 +47,7 @@ export class UpdateUser implements IUpdateUser {
         LoggerContextStatus.ERROR,
         LoggerContext.USECASE,
         LoggerContextEntity.USER,
-        `UpdateUser.execute | ${error.message}`
+        `UpdateUser.execute | ${error.message}`,
       );
       return {
         data: null,
@@ -58,7 +58,7 @@ export class UpdateUser implements IUpdateUser {
   }
 
   async executeInvertUserStatus(
-    id: number | string
+    id: number | string,
   ): Promise<GenericOutputDto<UserEntity>> {
     try {
       let user: UserEntity;
@@ -94,7 +94,7 @@ export class UpdateUser implements IUpdateUser {
         LoggerContextStatus.ERROR,
         LoggerContext.USECASE,
         LoggerContextEntity.USER,
-        `UpdateUser.executeDisableUser | ${error.message}`
+        `UpdateUser.executeDisableUser | ${error.message}`,
       );
       return {
         data: null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import * as dotenv from "dotenv";
-import { initializeApp } from "./contexts/app.context";
+import { initializeApp } from "@contexts/app.context";
 
 dotenv.config();
 

--- a/src/infrastructure/discord/DiscordService.ts
+++ b/src/infrastructure/discord/DiscordService.ts
@@ -5,7 +5,7 @@ import {
   GuildMember,
   PartialGuildMember,
 } from "discord.js";
-import { IDiscordService } from "../../domain/interfaces/services/IDiscordService";
+import { IDiscordService } from "@services/IDiscordService";
 
 export class DiscordService
   implements IDiscordService<Message, GuildMember, PartialGuildMember, Client>
@@ -16,7 +16,7 @@ export class DiscordService
   private onMessageHandlers: ((message: Message) => void)[] = [];
   private onNewUserHandlers: ((member: GuildMember) => void)[] = [];
   private onUserLeaveHandlers: ((
-    member: GuildMember | PartialGuildMember
+    member: GuildMember | PartialGuildMember,
   ) => void)[] = [];
 
   constructor(client: Client) {

--- a/src/infrastructure/persistence/repositories/UserRepository.ts
+++ b/src/infrastructure/persistence/repositories/UserRepository.ts
@@ -1,20 +1,23 @@
 import { PrismaClient, User } from "@prisma/client";
-import { IUserRepository } from "../../../domain/interfaces/repositories/IUserRepository";
+import { IUserRepository } from "@repositories/IUserRepository";
 import { PrismaService } from "../prisma/prismaService";
-import { UserEntity } from "../../../domain/entities/User";
-import { UserStatus } from "../../../domain/types/UserStatusEnum";
+import { UserEntity } from "@entities/User";
+import { UserStatus } from "@type/UserStatusEnum";
 import {
   LoggerContext,
   LoggerContextEntity,
   LoggerContextStatus,
-} from "../../../domain/types/LoggerContextEnum";
-import { ILoggerService } from "../../../domain/interfaces/services/ILogger";
+} from "@type/LoggerContextEnum";
+import { ILoggerService } from "@services/ILogger";
 
 export class UserRepository implements IUserRepository {
   private client: PrismaClient;
   private logger: ILoggerService;
 
-  constructor(private prisma: PrismaService, logger: ILoggerService) {
+  constructor(
+    private prisma: PrismaService,
+    logger: ILoggerService,
+  ) {
     this.client = this.prisma.getClient();
     this.logger = logger;
   }
@@ -36,7 +39,7 @@ export class UserRepository implements IUserRepository {
         LoggerContextStatus.ERROR,
         LoggerContext.REPOSITORY,
         LoggerContextEntity.USER,
-        `create | ${error.message}`
+        `create | ${error.message}`,
       );
     }
   }
@@ -53,7 +56,7 @@ export class UserRepository implements IUserRepository {
         LoggerContextStatus.ERROR,
         LoggerContext.REPOSITORY,
         LoggerContextEntity.USER,
-        `createMany | ${error.message}`
+        `createMany | ${error.message}`,
       );
     }
   }
@@ -66,7 +69,7 @@ export class UserRepository implements IUserRepository {
    */
   async findById(
     id: number,
-    includeInactive?: boolean
+    includeInactive?: boolean,
   ): Promise<UserEntity | null> {
     try {
       const result = await this.client.user.findUnique({
@@ -85,7 +88,7 @@ export class UserRepository implements IUserRepository {
         LoggerContextStatus.ERROR,
         LoggerContext.REPOSITORY,
         LoggerContextEntity.USER,
-        `findById | ${error.message}`
+        `findById | ${error.message}`,
       );
     }
   }
@@ -98,7 +101,7 @@ export class UserRepository implements IUserRepository {
    */
   async findByDiscordId(
     id: string,
-    includeInactive?: boolean
+    includeInactive?: boolean,
   ): Promise<UserEntity | null> {
     try {
       const result = await this.client.user.findUnique({
@@ -117,7 +120,7 @@ export class UserRepository implements IUserRepository {
         LoggerContextStatus.ERROR,
         LoggerContext.REPOSITORY,
         LoggerContextEntity.USER,
-        `findByDiscordId | ${error.message}`
+        `findByDiscordId | ${error.message}`,
       );
     }
   }
@@ -130,7 +133,7 @@ export class UserRepository implements IUserRepository {
    */
   async listAll(
     limit?: number,
-    includeInactive?: boolean
+    includeInactive?: boolean,
   ): Promise<UserEntity[]> {
     try {
       const results = await this.client.user.findMany({
@@ -149,7 +152,7 @@ export class UserRepository implements IUserRepository {
         LoggerContextStatus.ERROR,
         LoggerContext.REPOSITORY,
         LoggerContextEntity.USER,
-        `create | ${error.message}`
+        `create | ${error.message}`,
       );
     }
   }
@@ -163,7 +166,7 @@ export class UserRepository implements IUserRepository {
    */
   async updateById(
     id: number,
-    user: Partial<UserEntity>
+    user: Partial<UserEntity>,
   ): Promise<UserEntity | null> {
     try {
       const result = await this.client.user.update({
@@ -176,7 +179,7 @@ export class UserRepository implements IUserRepository {
         LoggerContextStatus.ERROR,
         LoggerContext.REPOSITORY,
         LoggerContextEntity.USER,
-        `updateById | ${error.message}`
+        `updateById | ${error.message}`,
       );
     }
   }
@@ -198,7 +201,7 @@ export class UserRepository implements IUserRepository {
         LoggerContextStatus.ERROR,
         LoggerContext.REPOSITORY,
         LoggerContextEntity.USER,
-        `deleteById | ${error.message}`
+        `deleteById | ${error.message}`,
       );
     }
   }
@@ -215,7 +218,7 @@ export class UserRepository implements IUserRepository {
       user.create_at,
       user.update_at,
       user.last_active,
-      user.email
+      user.email,
     );
   }
 

--- a/src/tests/config/constants.ts
+++ b/src/tests/config/constants.ts
@@ -1,4 +1,4 @@
-import { UserStatus } from "../../domain/types/UserStatusEnum";
+import { UserStatus } from "@type/UserStatusEnum";
 
 export type naturalizeUser = {
   id: number;

--- a/src/tests/context/databate.test.ts
+++ b/src/tests/context/databate.test.ts
@@ -8,10 +8,10 @@ jest.mock("@prisma/client", () => {
   };
 });
 
-import { initializeDatabase } from "../../contexts/database.context";
-import { ILoggerService } from "../../domain/interfaces/services/ILogger";
-import { PrismaService } from "../../infrastructure/persistence/prisma/prismaService";
-import { UserRepository } from "../../infrastructure/persistence/repositories/UserRepository";
+import { initializeDatabase } from "@contexts/database.context";
+import { ILoggerService } from "@services/ILogger";
+import { PrismaService } from "@infra/persistence/prisma/prismaService";
+import { UserRepository } from "@infra/repositories/UserRepository";
 import { PrismaClient } from "@prisma/client";
 
 describe("initializeDatabase", () => {

--- a/src/tests/context/useCases.test.ts
+++ b/src/tests/context/useCases.test.ts
@@ -1,5 +1,5 @@
 // Mock the database initialization
-jest.mock("../../contexts/database.context", () => ({
+jest.mock("@contexts/database.context", () => ({
   initializeDatabase: jest.fn(() => ({
     userRepository: {
       create: jest.fn(),
@@ -11,14 +11,14 @@ jest.mock("../../contexts/database.context", () => ({
 }));
 
 import { PrismaClient } from "@prisma/client";
-import { initializeDatabase } from "../../contexts/database.context";
-import { CreateUser } from "../../domain/useCases/user/CreateUser";
-import { FindUser } from "../../domain/useCases/user/FindUser";
-import { UpdateUser } from "../../domain/useCases/user/UpdateUser";
-import { PrismaService } from "../../infrastructure/persistence/prisma/prismaService";
+import { initializeDatabase } from "@contexts/database.context";
+import { CreateUser } from "@useCases/user/CreateUser";
+import { FindUser } from "@useCases/user/FindUser";
+import { UpdateUser } from "@useCases/user/UpdateUser";
+import { PrismaService } from "@infra/persistence/prisma/prismaService";
 import { mockUserValue } from "../config/constants";
-import { ILoggerService } from "../../domain/interfaces/services/ILogger";
-import { initializeUserUseCases } from "../../contexts/useUserCases.context";
+import { ILoggerService } from "@services/ILogger";
+import { initializeUserUseCases } from "@contexts/useUserCases.context";
 
 describe("initializeUserCases", () => {
   beforeEach(() => {
@@ -66,14 +66,14 @@ describe("initializeUserCases", () => {
     const findResult = await secondCall.findUserCase.execute(mockUserValue.id);
     const updateResult = await secondCall.updateUserCase.execute(
       mockUserValue.id,
-      mockUserValue
+      mockUserValue,
     );
 
     const createResult2 = await firstCall.createUserCase.execute(mockUserValue);
     const findResult2 = await firstCall.findUserCase.execute(mockUserValue.id);
     const updateResult2 = await firstCall.updateUserCase.execute(
       mockUserValue.id,
-      mockUserValue
+      mockUserValue,
     );
 
     expect(createResult).toEqual(createResult2);

--- a/src/tests/service/discord.test.ts
+++ b/src/tests/service/discord.test.ts
@@ -5,7 +5,7 @@ import {
   GuildMember,
   PartialGuildMember,
 } from "discord.js";
-import { DiscordService } from "../../infrastructure/discord/DiscordService";
+import { DiscordService } from "@discord/DiscordService";
 
 describe("DiscordService", () => {
   let client: Client;
@@ -27,19 +27,19 @@ describe("DiscordService", () => {
 
     expect(client.once).toHaveBeenCalledWith(
       Events.ClientReady,
-      expect.any(Function)
+      expect.any(Function),
     );
     expect(client.on).toHaveBeenCalledWith(
       Events.MessageCreate,
-      expect.any(Function)
+      expect.any(Function),
     );
     expect(client.on).toHaveBeenCalledWith(
       Events.GuildMemberAdd,
-      expect.any(Function)
+      expect.any(Function),
     );
     expect(client.on).toHaveBeenCalledWith(
       Events.GuildMemberRemove,
-      expect.any(Function)
+      expect.any(Function),
     );
   });
 
@@ -51,7 +51,7 @@ describe("DiscordService", () => {
 
     discordService.registerEvents();
     const readyCallback = (client.once as jest.Mock).mock.calls.find(
-      (call) => call[0] === Events.ClientReady
+      (call) => call[0] === Events.ClientReady,
     )?.[1];
 
     readyCallback?.(); // Simulate client ready event
@@ -66,7 +66,7 @@ describe("DiscordService", () => {
 
     discordService.registerEvents();
     const messageCallback = (client.on as jest.Mock).mock.calls.find(
-      (call) => call[0] === Events.MessageCreate
+      (call) => call[0] === Events.MessageCreate,
     )?.[1];
 
     const mockMessage = { content: "Hello" } as Message;
@@ -81,7 +81,7 @@ describe("DiscordService", () => {
 
     discordService.registerEvents();
     const joinCallback = (client.on as jest.Mock).mock.calls.find(
-      (call) => call[0] === Events.GuildMemberAdd
+      (call) => call[0] === Events.GuildMemberAdd,
     )?.[1];
 
     const mockMember = { id: "1234" } as GuildMember;
@@ -96,7 +96,7 @@ describe("DiscordService", () => {
 
     discordService.registerEvents();
     const leaveCallback = (client.on as jest.Mock).mock.calls.find(
-      (call) => call[0] === Events.GuildMemberRemove
+      (call) => call[0] === Events.GuildMemberRemove,
     )?.[1];
 
     const mockMember = { id: "5678" } as PartialGuildMember;

--- a/src/tests/service/log.test.ts
+++ b/src/tests/service/log.test.ts
@@ -1,9 +1,9 @@
-import { Logger } from "../../application/services/Logger";
+import { Logger } from "@application/services/Logger";
 import {
   LoggerContextStatus,
   LoggerContext,
   LoggerContextEntity,
-} from "../../domain/types/LoggerContextEnum";
+} from "@type/LoggerContextEnum";
 
 describe("Logger Service", () => {
   let logger: Logger;
@@ -23,11 +23,11 @@ describe("Logger Service", () => {
       LoggerContextStatus.SUCCESS,
       LoggerContext.REPOSITORY,
       LoggerContextEntity.USER,
-      "User created successfully"
+      "User created successfully",
     );
 
     expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('"status":"SUCCESS"')
+      expect.stringContaining('"status":"SUCCESS"'),
     );
   });
 
@@ -36,11 +36,11 @@ describe("Logger Service", () => {
       LoggerContextStatus.ERROR,
       LoggerContext.COMMAND,
       LoggerContextEntity.USER,
-      "Authentication failed"
+      "Authentication failed",
     );
 
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('"status":"ERROR"')
+      expect.stringContaining('"status":"ERROR"'),
     );
   });
 
@@ -49,11 +49,11 @@ describe("Logger Service", () => {
       LoggerContextStatus.ERROR,
       LoggerContext.SERVICE,
       LoggerContextEntity.USER,
-      "User update delayed"
+      "User update delayed",
     );
 
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('"message":"User update delayed"')
+      expect.stringContaining('"message":"User update delayed"'),
     );
   });
 
@@ -62,11 +62,11 @@ describe("Logger Service", () => {
       LoggerContextStatus.SUCCESS,
       LoggerContext.INFRASTRUCTURE,
       LoggerContextEntity.USER,
-      "Debugging process"
+      "Debugging process",
     );
 
     expect(console.log).toHaveBeenCalledWith(
-      expect.stringMatching(/"createdAt":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/) // Matches ISO date format
+      expect.stringMatching(/"createdAt":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/), // Matches ISO date format
     );
   });
 });

--- a/src/tests/user/repository.test.ts
+++ b/src/tests/user/repository.test.ts
@@ -1,8 +1,8 @@
-import { UserEntity } from "../../domain/entities/User";
-import { ILoggerService } from "../../domain/interfaces/services/ILogger";
-import { UserStatus } from "../../domain/types/UserStatusEnum";
-import { PrismaService } from "../../infrastructure/persistence/prisma/prismaService";
-import { UserRepository } from "../../infrastructure/persistence/repositories/UserRepository";
+import { UserEntity } from "@entities/User";
+import { ILoggerService } from "@services/ILogger";
+import { UserStatus } from "@type/UserStatusEnum";
+import { PrismaService } from "@infra/persistence/prisma/prismaService";
+import { UserRepository } from "@infra/repositories/UserRepository";
 import { mockDBUserValue, mockUserUpdateValue } from "../config/constants";
 import { prismaMock } from "../config/singleton";
 

--- a/src/tests/user/useCases.test.ts
+++ b/src/tests/user/useCases.test.ts
@@ -1,11 +1,11 @@
-import { UserRepository } from "../../infrastructure/persistence/repositories/UserRepository";
+import { UserRepository } from "@infra/repositories/UserRepository";
 import { mockDeep, MockProxy } from "jest-mock-extended";
-import { CreateUser } from "../../domain/useCases/user/CreateUser";
-import { FindUser } from "../../domain/useCases/user/FindUser";
-import { UpdateUser } from "../../domain/useCases/user/UpdateUser";
-import { UserStatus } from "../../domain/types/UserStatusEnum";
-import { ErrorMessages } from "../../domain/types/ErrorMessages";
-import { ILoggerService } from "../../domain/interfaces/services/ILogger";
+import { CreateUser } from "@useCases/user/CreateUser";
+import { FindUser } from "@useCases/user/FindUser";
+import { UpdateUser } from "@useCases/user/UpdateUser";
+import { UserStatus } from "@type/UserStatusEnum";
+import { ErrorMessages } from "@type/ErrorMessages";
+import { ILoggerService } from "@services/ILogger";
 
 // Mock da entidade que representa o usuário no banco de dados.
 const mockUserValue = {
@@ -88,7 +88,7 @@ describe("User useCases", () => {
       expect(userRepository.findByDiscordId).toHaveBeenCalledTimes(1);
       expect(userRepository.findByDiscordId).toHaveBeenCalledWith(
         mockUserValue2.discordId,
-        true
+        true,
       );
     });
 
@@ -144,7 +144,7 @@ describe("User useCases", () => {
           .filter((user) => !user.bot)
           .map((user) => ({
             ...user,
-          }))
+          })),
       );
     });
   });
@@ -199,7 +199,7 @@ describe("User useCases", () => {
           status: UserStatus.ACTIVE,
           bot: false,
           discordId: mockUserValue2.discordId,
-        })
+        }),
       );
     });
 
@@ -227,7 +227,7 @@ describe("User useCases", () => {
           status: UserStatus.ACTIVE,
           bot: false,
           discordId: mockUserValue2.discordId,
-        })
+        }),
       );
     });
 
@@ -254,12 +254,6 @@ describe("User useCases", () => {
 
     it("should disable an user", async () => {
       const id = 2;
-      const userData = {
-        discordId: "1234567890",
-        username: "Jane Doe",
-        bot: false,
-        status: UserStatus.ACTIVE,
-      };
 
       userRepository.updateById.mockResolvedValue(mockUserValue2);
       userRepository.findById.mockResolvedValue(mockUserValue2);
@@ -275,7 +269,7 @@ describe("User useCases", () => {
           status: UserStatus.INACTIVE,
           bot: false,
           discordId: mockUserValue2.discordId,
-        })
+        }),
       );
     });
   });

--- a/src/tests/user/userCommands.test.ts
+++ b/src/tests/user/userCommands.test.ts
@@ -1,7 +1,7 @@
-import { UserCommand } from "../../application/command/userCommand";
-import { IDiscordService } from "../../domain/interfaces/services/IDiscordService";
-import { ICreateUser } from "../../domain/interfaces/useCases/user/ICreateUser";
-import { IUpdateUser } from "../../domain/interfaces/useCases/user/IUpdateUser";
+import { UserCommand } from "@application/command/userCommand";
+import { IDiscordService } from "@services/IDiscordService";
+import { ICreateUser } from "@interfaces/useCases/user/ICreateUser";
+import { IUpdateUser } from "@interfaces/useCases/user/IUpdateUser";
 import {
   Client,
   Collection,
@@ -10,9 +10,9 @@ import {
   Message,
   PartialGuildMember,
 } from "discord.js";
-import { ILoggerService } from "../../domain/interfaces/services/ILogger";
+import { ILoggerService } from "@services/ILogger";
 
-jest.mock("../../domain/interfaces/services/ILogger");
+jest.mock("@services/ILogger");
 
 describe("UserCommand", () => {
   let discordService: jest.Mocked<
@@ -53,7 +53,7 @@ describe("UserCommand", () => {
       discordService,
       {} as ILoggerService,
       createUser,
-      updateUser
+      updateUser,
     );
   });
 
@@ -70,14 +70,14 @@ describe("UserCommand", () => {
     } as GuildMember;
     const handler = jest.fn();
     (discordService.onNewUser as jest.Mock).mockImplementation(
-      (cb) => handler.mockImplementation(cb) // Capture the callback for later execution
+      (cb) => handler.mockImplementation(cb), // Capture the callback for later execution
     );
 
     await userCommand.executeNewUser();
     handler(mockMember); // Simulate a user joining
 
     expect(createUser.execute).toHaveBeenCalledWith(
-      UserCommand.toUserEntity(mockMember)
+      UserCommand.toUserEntity(mockMember),
     );
   });
 
@@ -110,7 +110,7 @@ describe("UserCommand", () => {
           new Collection([
             ["123", mockMember1],
             ["456", mockMember2],
-          ])
+          ]),
         ),
       },
     } as unknown as Guild;
@@ -127,7 +127,7 @@ describe("UserCommand", () => {
     const members = await guild.members.fetch();
 
     expect(createUser.executeMany).toHaveBeenCalledWith(
-      members.map((member) => UserCommand.toUserEntity(member))
+      members.map((member) => UserCommand.toUserEntity(member)),
     );
   });
 
@@ -135,7 +135,7 @@ describe("UserCommand", () => {
     const mockMember = { id: "123" } as GuildMember;
     const handler = jest.fn();
     (discordService.onUserLeave as jest.Mock).mockImplementation(
-      (cb) => handler.mockImplementation(cb) // Capture the callback
+      (cb) => handler.mockImplementation(cb), // Capture the callback
     );
 
     await userCommand.executeUserLeave();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,38 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "esModuleInterop": true,
-        "target": "es6",
-        "moduleResolution": "node",
-        "sourceMap": true,
-        "outDir": "dist",
-        "skipLibCheck": true,
-        "emitDecoratorMetadata": true,
-        "experimentalDecorators": true
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "target": "es6",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "rootDir": "src",
+    "paths": {
+      "@application/*": ["application/*"],
+      "@contexts/*": ["contexts/*"],
+      "@domain/*": ["domain/*"],
+      "@dtos/*": ["domain/dtos/*"],
+      "@entities/*": ["domain/entities/*"],
+      "@interfaces/*": ["domain/interfaces/*"],
+      "@repositories/*": ["domain/interfaces/repositories/*"],
+      "@services/*": ["domain/interfaces/services/*"],
+      "@useCases/*": ["domain/useCases/*"],
+      "@type/*": ["domain/types/*"],
+      "@infra/repositories/*": ["infrastructure/persistence/repositories/*"],
+      "@infra/*": ["infrastructure/*"],
+      "@discord/*": ["infrastructure/discord/*"]
     },
-    "lib": [
-        "es2015"
-    ],
-    "include": ["src/**/**/*"],
-    "exclude": [
-        "**/*.test.ts",
-        "**/*.spec.ts",
-        "**/tests/**",
-        "**/__tests__/**",
-        "**/__mocks__/**"
-      ]
-
+    "baseUrl": "./src"
+  },
+  "ts-node": {
+    "require": ["tsconfig-paths/register"],
+    "transpileOnly": true,
+    "files": true
+  },
+  "lib": ["es2015"],
+  "include": ["src/**/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Tarefa no [Notion](https://www.notion.so/cpdd/Criar-path-alias-1c2c5f6d25f88092af94c54e2e165cf5)

- Adição de path aliases para simplificar os imports
- Ajuste dos imports da app com base nos aliases criados
- Setup para integração com jest e para funcionar com ts-node e tsc usando tsconfig-pathse tsc-alias
- Pequenos ajustes nos arquivos modificados para atender às necessidades do es-lint

Para verificar que tudo segue funcionando normalmente:

- npm test
- npm run dev (,env com DB_HOST=localhost)
- npm run prod (.env com DB_HOST=db)

Todos devem funcionar e chegar ao resultado final da app no estado atual: Criação dos registros na tabela de users