### PR TITLE
CPDD-278: DAL message reaction

### DIFF
--- a/src/contexts/database.context.ts
+++ b/src/contexts/database.context.ts
@@ -1,6 +1,9 @@
 import { PrismaService } from "@infra/persistence/prisma/prismaService";
 import { UserRepository } from "@infra/repositories/UserRepository";
 import { MessageRepository } from "@infra/persistence/repositories/MessageRepository";
+import { IMessageReactionRepository } from "@domain/interfaces/repositories/IMessageReactionRepository";
+import { MessageReactionRepository } from "@infra/persistence/repositories/MessageReactionRepository";
+
 import { IUserRepository } from "@repositories/IUserRepository";
 import { PrismaClient } from "@prisma/client";
 import { ILoggerService } from "@services/ILogger";
@@ -26,6 +29,7 @@ export function initializeDatabase(
 ): {
   userRepository: IUserRepository;
   messageRepository: IMessageRepository;
+  messageReactionRepository: IMessageReactionRepository;
   channelRepository: IChannelRepository;
   audioEventRepository: IAudioEventRepository;
 } {
@@ -37,6 +41,10 @@ export function initializeDatabase(
     logger,
   );
   const messageRepository = new MessageRepository(
+    prismaService ?? newPrismaService,
+    logger,
+  );
+  const messageReactionRepository = new MessageReactionRepository(
     prismaService ?? newPrismaService,
     logger,
   );
@@ -52,6 +60,7 @@ export function initializeDatabase(
   return {
     userRepository,
     messageRepository,
+    messageReactionRepository,
     channelRepository,
     audioEventRepository,
   };

--- a/src/domain/dtos/CreateMessageReactionData.ts
+++ b/src/domain/dtos/CreateMessageReactionData.ts
@@ -1,0 +1,5 @@
+export type CreateMessageReactionData = {
+  userId: string;
+  messageId: string;
+  channelId: string;
+};

--- a/src/domain/entities/Channel.ts
+++ b/src/domain/entities/Channel.ts
@@ -1,3 +1,5 @@
+import { Channel } from "@prisma/client";
+
 export class ChannelEntity {
   constructor(
     public readonly id: number,
@@ -6,4 +8,14 @@ export class ChannelEntity {
     public readonly url: string,
     public readonly createdAt: Date,
   ) {}
+
+  public static fromPersistence(channel: Channel): ChannelEntity {
+    return new ChannelEntity(
+      channel.id,
+      channel.platform_id,
+      channel.name,
+      channel.url,
+      channel.created_at,
+    );
+  }
 }

--- a/src/domain/entities/Message.ts
+++ b/src/domain/entities/Message.ts
@@ -1,3 +1,5 @@
+import { Message } from "@prisma/client";
+
 export class MessageEntity {
   constructor(
     public readonly channelId: string,
@@ -8,4 +10,16 @@ export class MessageEntity {
     public readonly id?: number | null,
     public readonly createdAt?: Date | null,
   ) {}
+
+  public static fromPersistence(message: Message): MessageEntity {
+    return new MessageEntity(
+      message.channel_id,
+      message.platform_id,
+      message.platform_created_at,
+      message.is_deleted,
+      message.user_id,
+      message.id,
+      message.created_at,
+    );
+  }
 }

--- a/src/domain/entities/MessageReaction.ts
+++ b/src/domain/entities/MessageReaction.ts
@@ -1,7 +1,12 @@
+import { ChannelEntity } from "./Channel";
+import { MessageEntity } from "./Message";
+import { UserEntity } from "./User";
+
 export class MessageReactionEntity {
   constructor(
-    public readonly userId: string,
-    public readonly messageId: string,
-    public readonly channelId: string,
+    public readonly id: number,
+    public readonly user: UserEntity,
+    public readonly message: MessageEntity,
+    public readonly channel: ChannelEntity,
   ) {}
 }

--- a/src/domain/entities/MessageReaction.ts
+++ b/src/domain/entities/MessageReaction.ts
@@ -1,0 +1,7 @@
+export class MessageReactionEntity {
+  constructor(
+    public readonly userId: string,
+    public readonly messageId: string,
+    public readonly channelId: string,
+  ) {}
+}

--- a/src/domain/entities/User.ts
+++ b/src/domain/entities/User.ts
@@ -1,4 +1,5 @@
 import { UserStatus } from "@type/UserStatusEnum";
+import { User } from "@prisma/client";
 
 export class UserEntity {
   // Deveria ser User, mas o discord ja tem User, é MUITO chato ficar importando a coisa errada toda hora.
@@ -16,4 +17,21 @@ export class UserEntity {
     public readonly lastActive?: Date | null,
     public readonly email?: string | null,
   ) {}
+
+  public static fromPersistence(user: User): UserEntity {
+    return new UserEntity(
+      user.id,
+      user.platform_id,
+      user.username,
+      user.bot,
+      user.status,
+      user.global_name,
+      user.joined_at,
+      user.platform_created_at,
+      user.create_at,
+      user.update_at,
+      user.last_active,
+      user.email,
+    );
+  }
 }

--- a/src/domain/interfaces/repositories/IMessageReactionRepository.ts
+++ b/src/domain/interfaces/repositories/IMessageReactionRepository.ts
@@ -1,0 +1,35 @@
+import { MessageReactionEntity } from "../../entities/MessageReaction";
+
+export interface IMessageReactionRepository {
+  create(
+    reaction: MessageReactionEntity,
+  ): Promise<MessageReactionEntity | null>;
+  createMany(reactions: MessageReactionEntity[]): Promise<number>;
+
+  getMessageReactionById(
+    userId: string,
+    messageId: string,
+  ): Promise<MessageReactionEntity | null>;
+
+  getMessageReactionByUserId(userId: string): Promise<MessageReactionEntity[]>;
+
+  getMessageReactionByUserDiscordId(
+    userId: string,
+  ): Promise<MessageReactionEntity[]>;
+
+  getMessageReactionByDiscordId(
+    userId: string,
+    messageId: string,
+  ): Promise<MessageReactionEntity | null>;
+
+  updateMessageReaction(
+    userId: string,
+    messageId: string,
+    data: Partial<MessageReactionEntity>,
+  ): Promise<MessageReactionEntity | null>;
+
+  deleteMessageReaction(
+    userId: string,
+    messageId: string,
+  ): Promise<MessageReactionEntity | null>;
+}

--- a/src/domain/interfaces/repositories/IMessageReactionRepository.ts
+++ b/src/domain/interfaces/repositories/IMessageReactionRepository.ts
@@ -1,10 +1,14 @@
 import { MessageReactionEntity } from "../../entities/MessageReaction";
+import { CreateMessageReactionData } from "../../dtos/CreateMessageReactionData";
+
+export type UpdateMessageReactionData = Partial<CreateMessageReactionData>;
 
 export interface IMessageReactionRepository {
   create(
-    reaction: MessageReactionEntity,
+    data: CreateMessageReactionData,
   ): Promise<MessageReactionEntity | null>;
-  createMany(reactions: MessageReactionEntity[]): Promise<number>;
+
+  createMany(data: CreateMessageReactionData[]): Promise<number>;
 
   getMessageReactionById(
     userId: string,
@@ -25,7 +29,7 @@ export interface IMessageReactionRepository {
   updateMessageReaction(
     userId: string,
     messageId: string,
-    data: Partial<MessageReactionEntity>,
+    data: UpdateMessageReactionData,
   ): Promise<MessageReactionEntity | null>;
 
   deleteMessageReaction(

--- a/src/domain/interfaces/repositories/IMessageReactionRepository.ts
+++ b/src/domain/interfaces/repositories/IMessageReactionRepository.ts
@@ -17,11 +17,11 @@ export interface IMessageReactionRepository {
 
   getMessageReactionByUserId(userId: string): Promise<MessageReactionEntity[]>;
 
-  getMessageReactionByUserDiscordId(
+  getMessageReactionByUserPlatformId(
     userId: string,
   ): Promise<MessageReactionEntity[]>;
 
-  getMessageReactionByDiscordId(
+  getMessageReactionByPlatformId(
     userId: string,
     messageId: string,
   ): Promise<MessageReactionEntity | null>;

--- a/src/domain/interfaces/repositories/IMessageReactionRepository.ts
+++ b/src/domain/interfaces/repositories/IMessageReactionRepository.ts
@@ -10,30 +10,18 @@ export interface IMessageReactionRepository {
 
   createMany(data: CreateMessageReactionData[]): Promise<number>;
 
-  getMessageReactionById(
-    userId: string,
-    messageId: string,
-  ): Promise<MessageReactionEntity | null>;
+  getMessageReactionById(id: number): Promise<MessageReactionEntity | null>;
 
   getMessageReactionByUserId(userId: string): Promise<MessageReactionEntity[]>;
 
   getMessageReactionByUserPlatformId(
-    userId: string,
+    userPlatformId: string,
   ): Promise<MessageReactionEntity[]>;
 
-  getMessageReactionByPlatformId(
-    userId: string,
-    messageId: string,
-  ): Promise<MessageReactionEntity | null>;
-
   updateMessageReaction(
-    userId: string,
-    messageId: string,
+    id: number,
     data: UpdateMessageReactionData,
   ): Promise<MessageReactionEntity | null>;
 
-  deleteMessageReaction(
-    userId: string,
-    messageId: string,
-  ): Promise<MessageReactionEntity | null>;
+  deleteMessageReaction(id: number): Promise<boolean>;
 }

--- a/src/domain/types/LoggerContextEnum.ts
+++ b/src/domain/types/LoggerContextEnum.ts
@@ -11,6 +11,7 @@ export enum LoggerContext {
 export enum LoggerContextEntity {
   USER = "USER",
   MESSAGE = "MESSAGE",
+  MESSAGE_REACTION = "MESSAGE_REACTION",
   CHANNEL = "CHANNEL",
   AUDIO_EVENT = "AUDIO_EVENT",
 }

--- a/src/infrastructure/persistence/prisma/models/dbml/schema.dbml
+++ b/src/infrastructure/persistence/prisma/models/dbml/schema.dbml
@@ -105,6 +105,7 @@ Table channel {
 }
 
 Table message_reaction {
+  id Int [pk, increment]
   user user [not null]
   user_id String [not null]
   message message [not null]
@@ -113,7 +114,7 @@ Table message_reaction {
   channel_id String [not null]
 
   indexes {
-    (user_id, message_id) [pk]
+    (user_id, message_id) [unique]
   }
 }
 

--- a/src/infrastructure/persistence/prisma/models/migrations/20250621204602_/migration.sql
+++ b/src/infrastructure/persistence/prisma/models/migrations/20250621204602_/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - The primary key for the `message_reaction` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - A unique constraint covering the columns `[user_id,message_id]` on the table `message_reaction` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `id` to the `message_reaction` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `message_reaction` DROP PRIMARY KEY,
+    ADD COLUMN `id` INTEGER NOT NULL AUTO_INCREMENT,
+    ADD PRIMARY KEY (`id`);
+
+-- CreateIndex
+CREATE UNIQUE INDEX `message_reaction_user_id_message_id_key` ON `message_reaction`(`user_id`, `message_id`);

--- a/src/infrastructure/persistence/prisma/models/schema.prisma
+++ b/src/infrastructure/persistence/prisma/models/schema.prisma
@@ -130,6 +130,7 @@ model Channel {
 }
 
 model MessageReaction {
+  id         Int     @id @default(autoincrement())
   user       User    @relation(fields: [user_id], references: [platform_id])
   user_id    String
   message    Message @relation(fields: [message_id], references: [platform_id])
@@ -137,6 +138,6 @@ model MessageReaction {
   channel    Channel @relation(fields: [channel_id], references: [platform_id])
   channel_id String
 
-  @@id([user_id, message_id])
+  @@unique([user_id, message_id])
   @@map("message_reaction")
 }

--- a/src/infrastructure/persistence/repositories/MessageReactionRepository.ts
+++ b/src/infrastructure/persistence/repositories/MessageReactionRepository.ts
@@ -130,13 +130,13 @@ export class MessageReactionRepository implements IMessageReactionRepository {
     }
   }
 
-  async getMessageReactionByUserDiscordId(
+  async getMessageReactionByUserPlatformId(
     userId: string,
   ): Promise<MessageReactionEntity[]> {
     return this.getMessageReactionByUserId(userId);
   }
 
-  async getMessageReactionByDiscordId(
+  async getMessageReactionByPlatformId(
     userId: string,
     messageId: string,
   ): Promise<MessageReactionEntity | null> {

--- a/src/infrastructure/persistence/repositories/MessageReactionRepository.ts
+++ b/src/infrastructure/persistence/repositories/MessageReactionRepository.ts
@@ -200,38 +200,9 @@ export class MessageReactionRepository implements IMessageReactionRepository {
   }
 
   private toDomain(reaction: FullMessageReaction): MessageReactionEntity {
-    const user = new UserEntity(
-      reaction.user.id,
-      reaction.user.platform_id,
-      reaction.user.username,
-      reaction.user.bot,
-      reaction.user.status,
-      reaction.user.global_name,
-      reaction.user.joined_at,
-      reaction.user.platform_created_at,
-      reaction.user.create_at,
-      reaction.user.update_at,
-      reaction.user.last_active,
-      reaction.user.email,
-    );
-
-    const message = new MessageEntity(
-      reaction.message.channel_id,
-      reaction.message.platform_id,
-      reaction.message.platform_created_at,
-      reaction.message.is_deleted,
-      reaction.message.user_id,
-      reaction.message.id,
-      reaction.message.created_at,
-    );
-
-    const channel = new ChannelEntity(
-      reaction.channel.id,
-      reaction.channel.platform_id,
-      reaction.channel.name,
-      reaction.channel.url,
-      reaction.channel.created_at,
-    );
+    const user = UserEntity.fromPersistence(reaction.user);
+    const message = MessageEntity.fromPersistence(reaction.message);
+    const channel = ChannelEntity.fromPersistence(reaction.channel);
 
     return new MessageReactionEntity(reaction.id, user, message, channel);
   }

--- a/src/infrastructure/persistence/repositories/MessageReactionRepository.ts
+++ b/src/infrastructure/persistence/repositories/MessageReactionRepository.ts
@@ -1,0 +1,216 @@
+import { PrismaClient, MessageReaction } from "@prisma/client";
+import { PrismaService } from "../prisma/prismaService";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "../../../domain/types/LoggerContextEnum";
+import { ILoggerService } from "../../../domain/interfaces/services/ILogger";
+import { IMessageReactionRepository } from "../../../domain/interfaces/repositories/IMessageReactionRepository";
+import { MessageReactionEntity } from "../../../domain/entities/MessageReaction";
+
+export class MessageReactionRepository implements IMessageReactionRepository {
+  private client: PrismaClient;
+  private logger: ILoggerService;
+
+  constructor(
+    private prisma: PrismaService,
+    logger: ILoggerService,
+  ) {
+    this.client = this.prisma.getClient();
+    this.logger = logger;
+  }
+
+  async create(
+    reaction: MessageReactionEntity,
+  ): Promise<MessageReactionEntity | null> {
+    try {
+      const result = await this.client.messageReaction.create({
+        data: this.toPersistence(reaction),
+      });
+      return this.toDomain(result);
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `create | ${error.message}`,
+      );
+      return null;
+    }
+  }
+
+  async createMany(reactions: MessageReactionEntity[]): Promise<number> {
+    try {
+      const result = await this.client.messageReaction.createMany({
+        data: reactions.map((reaction) => this.toPersistence(reaction)),
+        skipDuplicates: true,
+      });
+      return result.count;
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `createMany | ${error.message}`,
+      );
+      return 0;
+    }
+  }
+
+  async getMessageReactionById(
+    userId: string,
+    messageId: string,
+  ): Promise<MessageReactionEntity | null> {
+    try {
+      const result = await this.client.messageReaction.findUnique({
+        where: {
+          user_id_message_id: {
+            user_id: userId,
+            message_id: messageId,
+          },
+        },
+      });
+      return result ? this.toDomain(result) : null;
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `getMessageReactionById | ${error.message}`,
+      );
+      return null;
+    }
+  }
+
+  async getMessageReactionByUserId(
+    userId: string,
+  ): Promise<MessageReactionEntity[]> {
+    try {
+      const results = await this.client.messageReaction.findMany({
+        where: { user_id: userId },
+      });
+      return results.map((result) => this.toDomain(result));
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `getMessageReactionByUserId | ${error.message}`,
+      );
+      return [];
+    }
+  }
+
+  async getMessageReactionByUserDiscordId(
+    userId: string,
+  ): Promise<MessageReactionEntity[]> {
+    try {
+      const results = await this.client.messageReaction.findMany({
+        where: { user_id: userId },
+      });
+      return results.map((result) => this.toDomain(result));
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `getMessageReactionByUserDiscordId | ${error.message}`,
+      );
+      return [];
+    }
+  }
+
+  async getMessageReactionByDiscordId(
+    userId: string,
+    messageId: string,
+  ): Promise<MessageReactionEntity | null> {
+    try {
+      const result = await this.client.messageReaction.findUnique({
+        where: {
+          user_id_message_id: {
+            user_id: userId,
+            message_id: messageId,
+          },
+        },
+      });
+      return result ? this.toDomain(result) : null;
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `getMessageReactionByDiscordId | ${error.message}`,
+      );
+      return null;
+    }
+  }
+
+  async updateMessageReaction(
+    userId: string,
+    messageId: string,
+    data: Partial<MessageReactionEntity>,
+  ): Promise<MessageReactionEntity | null> {
+    try {
+      const result = await this.client.messageReaction.update({
+        where: {
+          user_id_message_id: {
+            user_id: userId,
+            message_id: messageId,
+          },
+        },
+        data: this.toPersistence(data),
+      });
+      return this.toDomain(result);
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `updateMessageReaction | ${error.message}`,
+      );
+      return null;
+    }
+  }
+
+  async deleteMessageReaction(
+    userId: string,
+    messageId: string,
+  ): Promise<MessageReactionEntity | null> {
+    try {
+      const result = await this.client.messageReaction.delete({
+        where: {
+          user_id_message_id: {
+            user_id: userId,
+            message_id: messageId,
+          },
+        },
+      });
+      return this.toDomain(result);
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `deleteMessageReaction | ${error.message}`,
+      );
+      return null;
+    }
+  }
+
+  private toDomain(reaction: MessageReaction): MessageReactionEntity {
+    return new MessageReactionEntity(
+      reaction.user_id,
+      reaction.message_id,
+      reaction.channel_id,
+    );
+  }
+
+  private toPersistence(reaction: Partial<MessageReactionEntity>) {
+    return {
+      user_id: reaction.userId,
+      message_id: reaction.messageId,
+      channel_id: reaction.channelId,
+    };
+  }
+}

--- a/src/tests/messageReaction/repository.test.ts
+++ b/src/tests/messageReaction/repository.test.ts
@@ -1,0 +1,205 @@
+import { MessageReaction } from "@prisma/client";
+import { MessageReactionEntity } from "../../domain/entities/MessageReaction";
+import { ILoggerService } from "../../domain/interfaces/services/ILogger";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "../../domain/types/LoggerContextEnum";
+import { PrismaService } from "../../infrastructure/persistence/prisma/prismaService";
+import { MessageReactionRepository } from "../../infrastructure/persistence/repositories/MessageReactionRepository";
+import { prismaMock } from "../config/singleton";
+
+// Mock de dados para os testes
+const mockDbMessageReaction: MessageReaction = {
+  user_id: "user123",
+  message_id: "message456",
+  channel_id: "channel789",
+};
+
+const mockMessageReactionEntity = new MessageReactionEntity(
+  mockDbMessageReaction.user_id,
+  mockDbMessageReaction.message_id,
+  mockDbMessageReaction.channel_id,
+);
+
+describe("MessageReactionRepository", () => {
+  let messageReactionRepository: MessageReactionRepository;
+  let mockLogger: ILoggerService;
+
+  beforeEach(() => {
+    mockLogger = {
+      logToConsole: jest.fn(),
+      logToDatabase: jest.fn(),
+    };
+    const prismaServiceMock = new PrismaService(prismaMock);
+    messageReactionRepository = new MessageReactionRepository(
+      prismaServiceMock,
+      mockLogger,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getMessageReactionById", () => {
+    it("should return a message reaction by user and message id", async () => {
+      prismaMock.messageReaction.findUnique.mockResolvedValue(
+        mockDbMessageReaction,
+      );
+
+      const result = await messageReactionRepository.getMessageReactionById(
+        mockMessageReactionEntity.userId,
+        mockMessageReactionEntity.messageId,
+      );
+
+      expect(prismaMock.messageReaction.findUnique).toHaveBeenCalledWith({
+        where: {
+          user_id_message_id: {
+            user_id: mockMessageReactionEntity.userId,
+            message_id: mockMessageReactionEntity.messageId,
+          },
+        },
+      });
+      expect(result).toEqual(mockMessageReactionEntity);
+    });
+
+    it("should return null if message reaction is not found", async () => {
+      prismaMock.messageReaction.findUnique.mockResolvedValue(null);
+
+      const result = await messageReactionRepository.getMessageReactionById(
+        "user1",
+        "message1",
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should log an error and return null if findUnique fails", async () => {
+      const error = new Error("DB error");
+      prismaMock.messageReaction.findUnique.mockRejectedValue(error);
+
+      const result = await messageReactionRepository.getMessageReactionById(
+        "user1",
+        "message1",
+      );
+
+      expect(mockLogger.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `getMessageReactionById | ${error.message}`,
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getMessageReactionByUserId", () => {
+    it("should return an array of message reactions for a given user id", async () => {
+      prismaMock.messageReaction.findMany.mockResolvedValue([
+        mockDbMessageReaction,
+      ]);
+
+      const result = await messageReactionRepository.getMessageReactionByUserId(
+        mockMessageReactionEntity.userId,
+      );
+
+      expect(prismaMock.messageReaction.findMany).toHaveBeenCalledWith({
+        where: { user_id: mockMessageReactionEntity.userId },
+      });
+      expect(result).toEqual([mockMessageReactionEntity]);
+      expect(result.length).toBe(1);
+    });
+
+    it("should return an empty array if no reactions are found for the user", async () => {
+      prismaMock.messageReaction.findMany.mockResolvedValue([]);
+
+      const result =
+        await messageReactionRepository.getMessageReactionByUserId(
+          "nonexistentuser",
+        );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("updateMessageReaction", () => {
+    it("should update a message reaction and return the updated entity", async () => {
+      const updatedData = { channelId: "newChannel123" };
+      const updatedDbReaction = {
+        ...mockDbMessageReaction,
+        channel_id: updatedData.channelId,
+      };
+      prismaMock.messageReaction.update.mockResolvedValue(updatedDbReaction);
+
+      const result = await messageReactionRepository.updateMessageReaction(
+        mockMessageReactionEntity.userId,
+        mockMessageReactionEntity.messageId,
+        updatedData,
+      );
+
+      expect(prismaMock.messageReaction.update).toHaveBeenCalledWith({
+        where: {
+          user_id_message_id: {
+            user_id: mockMessageReactionEntity.userId,
+            message_id: mockMessageReactionEntity.messageId,
+          },
+        },
+        data: {
+          user_id: undefined,
+          message_id: undefined,
+          channel_id: updatedData.channelId,
+        },
+      });
+      expect(result).toEqual(
+        new MessageReactionEntity(
+          updatedDbReaction.user_id,
+          updatedDbReaction.message_id,
+          updatedDbReaction.channel_id,
+        ),
+      );
+    });
+  });
+
+  describe("deleteMessageReaction", () => {
+    it("should delete a message reaction and return the deleted entity", async () => {
+      prismaMock.messageReaction.delete.mockResolvedValue(
+        mockDbMessageReaction,
+      );
+
+      const result = await messageReactionRepository.deleteMessageReaction(
+        mockMessageReactionEntity.userId,
+        mockMessageReactionEntity.messageId,
+      );
+
+      expect(prismaMock.messageReaction.delete).toHaveBeenCalledWith({
+        where: {
+          user_id_message_id: {
+            user_id: mockMessageReactionEntity.userId,
+            message_id: mockMessageReactionEntity.messageId,
+          },
+        },
+      });
+      expect(result).toEqual(mockMessageReactionEntity);
+    });
+
+    it("should log an error and return null if deletion fails", async () => {
+      const error = new Error("DB error");
+      prismaMock.messageReaction.delete.mockRejectedValue(error);
+
+      const result = await messageReactionRepository.deleteMessageReaction(
+        "user1",
+        "message1",
+      );
+
+      expect(mockLogger.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `deleteMessageReaction | ${error.message}`,
+      );
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Descrição
Esta alteração introduz a camada de acesso a dados (DAL) para a entidade `MessageReaction`.

Foram implementados a entidade de domínio, a interface do repositório e o repositório com os métodos de CRUD (`create`, `createMany`, `getMessageReactionById`, `getMessageReactionByUserId`, `updateMessageReaction`, `deleteMessageReaction`).

O novo repositório foi devidamente registrado no contexto da aplicação e coberto por testes unitários para garantir seu correto funcionamento.

## Link da tarefa
[CPDD-278](https://www.notion.so/cpdd/Check-in-Online-e61948851da14ce3b96b99f567b8baee?p=212c5f6d25f880bb92c6f7bd62618dfd&pm=s)

## Tipo de mudança
- [ ] Bugfix
- [x] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

## Como foi testado?
Foram criados testes unitários para a classe `MessageReactionRepository`, cobrindo todos os métodos implementados. Os testes utilizam mocks do Prisma para simular a interação com o banco de dados e validam os cenários de sucesso, falha e casos onde nenhum registro é encontrado.

Além disso, os testes de contexto existentes foram executados e corrigidos para garantir que a injeção do novo repositório não tenha introduzido regressões.

## Checklist
- [x] Código segue o padrão de estilo do projeto
- [x] Testes unitários foram adicionados
- [ ] A documentação foi atualizada (se aplicável)