### PR TITLE
Feat/cpdd 274 associar entidades channel

### DIFF
--- a/src/domain/entities/Channel.ts
+++ b/src/domain/entities/Channel.ts
@@ -1,21 +1,31 @@
-import { Channel } from "@prisma/client";
+import {Channel, Message, MessageReaction, User} from "@prisma/client";
+import {UserEntity} from "@entities/User";
+import {MessageEntity} from "@entities/Message";
+import {MessageReactionEntity} from "@entities/MessageReaction";
 
 export class ChannelEntity {
-  constructor(
-    public readonly id: number,
-    public readonly platformId: string,
-    public readonly name: string,
-    public readonly url: string,
-    public readonly createdAt: Date,
-  ) {}
+    constructor(
+        public readonly id: number,
+        public readonly platformId: string,
+        public readonly name: string,
+        public readonly url: string,
+        public readonly createdAt: Date,
+        public readonly user?: UserEntity[],
+        public readonly message?: MessageEntity[],
+        public readonly messageReaction?: MessageReactionEntity[],
+    ) {
+    }
 
-  public static fromPersistence(channel: Channel): ChannelEntity {
-    return new ChannelEntity(
-      channel.id,
-      channel.platform_id,
-      channel.name,
-      channel.url,
-      channel.created_at,
-    );
-  }
+    public static fromPersistence(channel: Channel, user?: User[], message?: Message[], messageReaction?: MessageReaction[]): ChannelEntity {
+        return new ChannelEntity(
+            channel.id,
+            channel.platform_id,
+            channel.name,
+            channel.url,
+            channel.created_at,
+            user.map(user => UserEntity.fromPersistence(user)),
+            message.map(message => MessageEntity.fromPersistence(message)),
+            messageReaction.map(messageReaction => MessageReactionEntity.fromPersistence(messageReaction))
+        );
+    }
 }

--- a/src/domain/entities/Channel.ts
+++ b/src/domain/entities/Channel.ts
@@ -1,31 +1,39 @@
-import {Channel, Message, MessageReaction, User} from "@prisma/client";
-import {UserEntity} from "@entities/User";
-import {MessageEntity} from "@entities/Message";
-import {MessageReactionEntity} from "@entities/MessageReaction";
+import { Channel, Message, MessageReaction, User } from "@prisma/client";
+import { UserEntity } from "@entities/User";
+import { MessageEntity } from "@entities/Message";
+import { MessageReactionEntity } from "@entities/MessageReaction";
 
 export class ChannelEntity {
-    constructor(
-        public readonly id: number,
-        public readonly platformId: string,
-        public readonly name: string,
-        public readonly url: string,
-        public readonly createdAt: Date,
-        public readonly user?: UserEntity[],
-        public readonly message?: MessageEntity[],
-        public readonly messageReaction?: MessageReactionEntity[],
-    ) {
-    }
+  constructor(
+    public readonly id: number,
+    public readonly platformId: string,
+    public readonly name: string,
+    public readonly url: string,
+    public readonly createdAt: Date,
+    public readonly user?: UserEntity[],
+    public readonly message?: MessageEntity[],
+    public readonly messageReaction?: MessageReactionEntity[],
+  ) {}
 
-    public static fromPersistence(channel: Channel, user?: User[], message?: Message[], messageReaction?: MessageReaction[]): ChannelEntity {
-        return new ChannelEntity(
-            channel.id,
-            channel.platform_id,
-            channel.name,
-            channel.url,
-            channel.created_at,
-            user.map(user => UserEntity.fromPersistence(user)),
-            message.map(message => MessageEntity.fromPersistence(message)),
-            messageReaction.map(messageReaction => MessageReactionEntity.fromPersistence(messageReaction))
-        );
-    }
+  public static fromPersistence(
+    channel: Channel,
+    user?: User[],
+    message?: Message[],
+    messageReaction?: MessageReaction[],
+  ): ChannelEntity {
+    return new ChannelEntity(
+      channel.id,
+      channel.platform_id,
+      channel.name,
+      channel.url,
+      channel.created_at,
+      (user ?? []).map((user) => UserEntity.fromPersistence(user)) || [],
+      (message ?? []).map((message) =>
+        MessageEntity.fromPersistence(message),
+      ) || [],
+      (messageReaction || []).map((messageReaction) =>
+        MessageReactionEntity.fromPersistence(messageReaction),
+      ) || [],
+    );
+  }
 }

--- a/src/domain/entities/MessageReaction.ts
+++ b/src/domain/entities/MessageReaction.ts
@@ -1,12 +1,23 @@
 import { ChannelEntity } from "./Channel";
 import { MessageEntity } from "./Message";
 import { UserEntity } from "./User";
+import {Channel, Message, MessageReaction, User} from "@prisma/client";
 
 export class MessageReactionEntity {
   constructor(
     public readonly id: number,
-    public readonly user: UserEntity,
-    public readonly message: MessageEntity,
-    public readonly channel: ChannelEntity,
-  ) {}
+    public readonly user?: UserEntity,
+    public readonly message?: MessageEntity,
+    public readonly channel?: ChannelEntity,
+  ) {
+  }
+
+  public static fromPersistence(messageReact: MessageReaction, user?: User, message?: Message, channel?: Channel): MessageReactionEntity {
+    return new MessageReactionEntity(
+        messageReact.id,
+        UserEntity.fromPersistence(user),
+        MessageEntity.fromPersistence(message),
+        ChannelEntity.fromPersistence(channel)
+    );
+  }
 }

--- a/src/domain/entities/User.ts
+++ b/src/domain/entities/User.ts
@@ -16,6 +16,7 @@ export class UserEntity {
     public readonly updateAt?: Date | null,
     public readonly lastActive?: Date | null,
     public readonly email?: string | null,
+    public readonly channelId?: number | null,
   ) {}
 
   public static fromPersistence(user: User): UserEntity {
@@ -32,6 +33,7 @@ export class UserEntity {
       user.update_at,
       user.last_active,
       user.email,
+      user.channelId,
     );
   }
 }

--- a/src/infrastructure/persistence/prisma/models/dbml/schema.dbml
+++ b/src/infrastructure/persistence/prisma/models/dbml/schema.dbml
@@ -4,39 +4,41 @@
 
 Table user {
   id Int [pk, increment]
-  platform_id String [unique, not null]
   username String [not null]
   global_name String
   joined_at DateTime
-  platform_created_at DateTime
   update_at DateTime
   last_active DateTime
   create_at DateTime [default: `now()`]
   bot Boolean [not null]
   email String
   status Int [not null]
-  user_role user_role [not null]
-  user_event user_event [not null]
+  platform_created_at DateTime
+  platform_id String [unique, not null]
+  channelId Int
+  audio_event audio_event [not null]
   message message [not null]
   message_reaction message_reaction [not null]
-  audio_event audio_event [not null]
+  Channel channel
   user_channel user_channel [not null]
+  user_event user_event [not null]
+  user_role user_role [not null]
 }
 
 Table role {
   id Int [pk, increment]
-  platform_id String [unique, not null]
   name String [not null]
-  platform_created_at DateTime [not null]
   created_at DateTime [default: `now()`, not null]
+  platform_created_at DateTime [not null]
+  platform_id String [unique, not null]
   user_role user_role [not null]
 }
 
 Table user_role {
-  user user [not null]
   user_id String [not null]
-  role role [not null]
   roleId String [not null]
+  role role [not null]
+  user user [not null]
 
   indexes {
     (user_id, roleId) [pk]
@@ -45,36 +47,36 @@ Table user_role {
 
 Table audio_event {
   id Int [pk, increment]
-  platform_id String [unique, not null]
   channel_id String [not null]
-  channel channel [not null]
   creator_id String [not null]
-  creator user [not null]
   name String [not null]
   description String
-  status event_status [not null]
   status_id String [not null]
   start_at DateTime [not null]
   end_at DateTime [not null]
   user_count Int [not null]
-  user_event user_event [not null]
   image String
   created_at DateTime [default: `now()`, not null]
+  platform_id String [unique, not null]
+  channel channel [not null]
+  creator user [not null]
+  status event_status [not null]
+  user_event user_event [not null]
 }
 
 Table event_status {
   id Int [pk, increment]
-  platform_id String [unique, not null]
   name String [not null]
-  event audio_event [not null]
   created_at DateTime [default: `now()`, not null]
+  platform_id String [unique, not null]
+  event audio_event [not null]
 }
 
 Table user_event {
-  event audio_event [not null]
   event_id String [not null]
-  user user [not null]
   user_id String [not null]
+  event audio_event [not null]
+  user user [not null]
 
   indexes {
     (user_id, event_id) [pk]
@@ -83,37 +85,38 @@ Table user_event {
 
 Table message {
   id Int [pk, increment]
-  platform_id String [unique, not null]
   channel_id String [not null]
-  channel channel [not null]
-  is_deleted Boolean [not null, default: false]
   user_id String [not null]
-  user user [not null]
-  platform_created_at DateTime [not null]
   created_at DateTime [default: `now()`, not null]
+  is_deleted Boolean [not null, default: false]
+  platform_created_at DateTime [not null]
+  platform_id String [unique, not null]
+  channel channel [not null]
+  user user [not null]
   message_reaction message_reaction [not null]
 }
 
 Table channel {
   id Int [pk, increment]
-  platform_id String [unique, not null]
   name String [not null]
   url String [not null]
-  message message [not null]
-  audio_event audio_event [not null]
-  message_reaction message_reaction [not null]
-  user_channel user_channel [not null]
   created_at DateTime [default: `now()`, not null]
+  platform_id String [unique, not null]
+  audio_event audio_event [not null]
+  message message [not null]
+  message_reaction message_reaction [not null]
+  User user [not null]
+  user_channel user_channel [not null]
 }
 
 Table message_reaction {
-  id Int [pk, increment]
-  user user [not null]
   user_id String [not null]
-  message message [not null]
   message_id String [not null]
-  channel channel [not null]
   channel_id String [not null]
+  id Int [pk, increment]
+  channel channel [not null]
+  message message [not null]
+  user user [not null]
 
   indexes {
     (user_id, message_id) [unique]
@@ -121,19 +124,21 @@ Table message_reaction {
 }
 
 Table user_channel {
-  user user [not null]
   user_id String [not null]
-  channel channel [not null]
   channel_id String [not null]
+  channel channel [not null]
+  user user [not null]
 
   indexes {
     (user_id, channel_id) [pk]
   }
 }
 
-Ref: user_role.user_id > user.platform_id
+Ref: user.channelId > channel.id
 
 Ref: user_role.roleId > role.platform_id
+
+Ref: user_role.user_id > user.platform_id
 
 Ref: audio_event.channel_id > channel.platform_id
 
@@ -149,12 +154,12 @@ Ref: message.channel_id > channel.platform_id
 
 Ref: message.user_id > user.platform_id
 
-Ref: message_reaction.user_id > user.platform_id
+Ref: message_reaction.channel_id > channel.platform_id
 
 Ref: message_reaction.message_id > message.platform_id
 
-Ref: message_reaction.channel_id > channel.platform_id
-
-Ref: user_channel.user_id > user.platform_id
+Ref: message_reaction.user_id > user.platform_id
 
 Ref: user_channel.channel_id > channel.platform_id
+
+Ref: user_channel.user_id > user.platform_id

--- a/src/infrastructure/persistence/prisma/models/dbml/schema.dbml
+++ b/src/infrastructure/persistence/prisma/models/dbml/schema.dbml
@@ -105,7 +105,7 @@ Table channel {
   audio_event audio_event [not null]
   message message [not null]
   message_reaction message_reaction [not null]
-  User user [not null]
+  user user [not null]
   user_channel user_channel [not null]
 }
 

--- a/src/infrastructure/persistence/prisma/models/migrations/20250727185237_/migration.sql
+++ b/src/infrastructure/persistence/prisma/models/migrations/20250727185237_/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE `user` ADD COLUMN `channelId` INTEGER NULL;
+
+-- AddForeignKey
+ALTER TABLE `user` ADD CONSTRAINT `user_channelId_fkey` FOREIGN KEY (`channelId`) REFERENCES `channel`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/src/infrastructure/persistence/prisma/models/schema.prisma
+++ b/src/infrastructure/persistence/prisma/models/schema.prisma
@@ -1,9 +1,3 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
-// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
-// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
-
 generator client {
   provider = "prisma-client-js"
 }
@@ -19,137 +13,151 @@ datasource db {
 
 model User {
   id                  Int               @id @default(autoincrement())
-  platform_id         String            @unique
   username            String
   global_name         String?
   joined_at           DateTime?
-  platform_created_at DateTime?
   update_at           DateTime?         @updatedAt
   last_active         DateTime?
   create_at           DateTime?         @default(now())
   bot                 Boolean
   email               String?
   status              Int
-  user_role           UserRole[]
-  user_event          userEvent[]
+  platform_created_at DateTime?
+  platform_id         String            @unique
+  channelId           Int?
+  audio_event         AudioEvent[]
   message             Message[]
   message_reaction    MessageReaction[]
-  audio_event         AudioEvent[]
+  Channel             Channel?          @relation(fields: [channelId], references: [id])
   user_channel        UserChannel[]
+  user_event          userEvent[]
+  user_role           UserRole[]
 
+  @@index([channelId], map: "user_channelId_fkey")
   @@map("user")
 }
 
 model Role {
   id                  Int        @id @default(autoincrement())
-  platform_id         String     @unique
   name                String
-  platform_created_at DateTime
   created_at          DateTime   @default(now())
+  platform_created_at DateTime
+  platform_id         String     @unique
   user_role           UserRole[]
 
   @@map("role")
 }
 
 model UserRole {
-  user    User   @relation(fields: [user_id], references: [platform_id])
   user_id String
-  role    Role   @relation(fields: [roleId], references: [platform_id])
   roleId  String
+  role    Role   @relation(fields: [roleId], references: [platform_id])
+  user    User   @relation(fields: [user_id], references: [platform_id])
 
   @@id([user_id, roleId])
+  @@index([roleId], map: "user_role_roleId_fkey")
   @@map("user_role")
 }
 
 model AudioEvent {
   id          Int         @id @default(autoincrement())
-  platform_id String      @unique
   channel_id  String
-  channel     Channel     @relation(fields: [channel_id], references: [platform_id])
   creator_id  String
-  creator     User        @relation(fields: [creator_id], references: [platform_id])
   name        String
   description String?
-  status      EventStatus @relation(fields: [status_id], references: [platform_id])
   status_id   String
   start_at    DateTime
   end_at      DateTime
   user_count  Int
-  user_event  userEvent[]
   image       String?
   created_at  DateTime    @default(now())
+  platform_id String      @unique
+  channel     Channel     @relation(fields: [channel_id], references: [platform_id])
+  creator     User        @relation(fields: [creator_id], references: [platform_id])
+  status      EventStatus @relation(fields: [status_id], references: [platform_id])
+  user_event  userEvent[]
 
+  @@index([channel_id], map: "audio_event_channel_id_fkey")
+  @@index([creator_id], map: "audio_event_creator_id_fkey")
+  @@index([status_id], map: "audio_event_status_id_fkey")
   @@map("audio_event")
 }
 
 model EventStatus {
   id          Int          @id @default(autoincrement())
-  platform_id String       @unique
   name        String
-  event       AudioEvent[]
   created_at  DateTime     @default(now())
+  platform_id String       @unique
+  event       AudioEvent[]
 
   @@map("event_status")
 }
 
 model userEvent {
-  event    AudioEvent @relation(fields: [event_id], references: [platform_id])
   event_id String
-  user     User       @relation(fields: [user_id], references: [platform_id])
   user_id  String
+  event    AudioEvent @relation(fields: [event_id], references: [platform_id])
+  user     User       @relation(fields: [user_id], references: [platform_id])
 
   @@id([user_id, event_id])
+  @@index([event_id], map: "user_event_event_id_fkey")
   @@map("user_event")
 }
 
 model Message {
   id                  Int               @id @default(autoincrement())
-  platform_id         String            @unique
   channel_id          String
-  channel             Channel           @relation(fields: [channel_id], references: [platform_id])
-  is_deleted          Boolean           @default(false)
   user_id             String
-  user                User              @relation(fields: [user_id], references: [platform_id])
-  platform_created_at DateTime
   created_at          DateTime          @default(now())
+  is_deleted          Boolean           @default(false)
+  platform_created_at DateTime
+  platform_id         String            @unique
+  channel             Channel           @relation(fields: [channel_id], references: [platform_id])
+  user                User              @relation(fields: [user_id], references: [platform_id])
   message_reaction    MessageReaction[]
 
+  @@index([channel_id], map: "message_channel_id_fkey")
+  @@index([user_id], map: "message_user_id_fkey")
   @@map("message")
 }
 
 model Channel {
   id               Int               @id @default(autoincrement())
-  platform_id      String            @unique
   name             String
   url              String
-  message          Message[]
-  audio_event      AudioEvent[]
-  message_reaction MessageReaction[]
-  user_channel     UserChannel[]
   created_at       DateTime          @default(now())
+  platform_id      String            @unique
+  audio_event      AudioEvent[]
+  message          Message[]
+  message_reaction MessageReaction[]
+  User             User[]
+  user_channel     UserChannel[]
 
   @@map("channel")
 }
 
 model MessageReaction {
-  id         Int     @id @default(autoincrement())
-  user       User    @relation(fields: [user_id], references: [platform_id])
   user_id    String
-  message    Message @relation(fields: [message_id], references: [platform_id])
   message_id String
-  channel    Channel @relation(fields: [channel_id], references: [platform_id])
   channel_id String
+  id         Int     @id @default(autoincrement())
+  channel    Channel @relation(fields: [channel_id], references: [platform_id])
+  message    Message @relation(fields: [message_id], references: [platform_id])
+  user       User    @relation(fields: [user_id], references: [platform_id])
 
   @@unique([user_id, message_id])
+  @@index([channel_id], map: "message_reaction_channel_id_fkey")
+  @@index([message_id], map: "message_reaction_message_id_fkey")
   @@map("message_reaction")
 }
 
 model UserChannel {
-  user       User    @relation(fields: [user_id], references: [platform_id])
   user_id    String
-  channel    Channel @relation(fields: [channel_id], references: [platform_id])
   channel_id String
+  channel    Channel @relation(fields: [channel_id], references: [platform_id])
+  user       User    @relation(fields: [user_id], references: [platform_id])
 
   @@id([user_id, channel_id])
+  @@index([channel_id], map: "user_channel_channel_id_fkey")
   @@map("user_channel")
 }

--- a/src/infrastructure/persistence/prisma/models/schema.prisma
+++ b/src/infrastructure/persistence/prisma/models/schema.prisma
@@ -130,7 +130,7 @@ model Channel {
   audio_event      AudioEvent[]
   message          Message[]
   message_reaction MessageReaction[]
-  User             User[]
+  user             User[]
   user_channel     UserChannel[]
 
   @@map("channel")

--- a/src/infrastructure/persistence/repositories/ChannelRepository.ts
+++ b/src/infrastructure/persistence/repositories/ChannelRepository.ts
@@ -30,8 +30,14 @@ export class ChannelRepository implements IChannelRepository {
   async create(channel: Omit<ChannelEntity, "id">): Promise<ChannelEntity> {
     try {
       const result = await this.client.channel.create({
-        data: this.toPersistence(channel),
+        data: {
+          user: { connect: { platform_id: channel.user } },
+          message: { connect: { platform_id: channel.messageId } },
+          messageReaction: { connect: { platform_id: channel.channelId } },
+        },
+        include: { user: true, message: true, messageReaction: true },
       });
+
       return this.toDomain(result);
     } catch (error) {
       this.logger.logToConsole(
@@ -186,6 +192,9 @@ export class ChannelRepository implements IChannelRepository {
       channel.name,
       channel.url,
       channel.created_at,
+      undefined,
+      undefined,
+      undefined
     );
   }
 
@@ -194,7 +203,7 @@ export class ChannelRepository implements IChannelRepository {
       platform_id: channel.platformId,
       name: channel.name,
       url: channel.url,
-      created_at: channel.createdAt,
+      created_at: channel.createdAt
     };
   }
 }

--- a/src/tests/channel/repository.test.ts
+++ b/src/tests/channel/repository.test.ts
@@ -6,8 +6,9 @@ import {
   mockDbChannelValue,
   mockChannelEntityValue,
   mockChannelUpdatePayload,
-  mockDbChannelUpdatedValue,
+  mockDbChannelUpdatedValue, mockDBUserValue,
 } from "@tests/config/constants";
+import {User} from "discord.js";
 
 describe("ChannelRepository", () => {
   let channelRepository: ChannelRepository;
@@ -42,7 +43,9 @@ describe("ChannelRepository", () => {
       expect(channel).toHaveProperty("platformId", "discordId");
       expect(channel).toHaveProperty("name", "channelName");
       expect(channel).toHaveProperty("url", "channelUrl");
-      expect(channel).toHaveProperty("createdAt", expect.any(Date));
+      expect(channel).toHaveProperty("user", expect.any(Object));
+      expect(channel).toHaveProperty("message", expect.any(Object));
+      expect(channel).toHaveProperty("messageReactionEntity", expect.any(Object));
     });
 
     it("should return null if channel not found", async () => {
@@ -106,6 +109,9 @@ describe("ChannelRepository", () => {
         name: "newChannelName",
         url: "newChannelUrl",
         createdAt: new Date(),
+        user: mockDBUserValue,
+        message: mockDBUserValue,
+        user: mockDBUserValue
       };
       const dbChannelData = {
         id: 2,
@@ -113,6 +119,9 @@ describe("ChannelRepository", () => {
         name: channelData.name,
         url: channelData.url,
         created_at: channelData.createdAt,
+        user: channelData.user,
+        message: channelData.message,
+        messageReactionEntity: channelData.messageReactionEntity
       };
       prismaMock.channel.create.mockResolvedValue(dbChannelData);
 

--- a/src/tests/config/constants.ts
+++ b/src/tests/config/constants.ts
@@ -15,6 +15,7 @@ export type naturalizeUser = {
   last_active: Date | null;
   bot: boolean;
   email: string | null;
+  channelId: number | null;
 };
 
 export const mockDBUserValue = {
@@ -133,6 +134,9 @@ export const mockDbChannelValue = {
   created_at: new Date(),
   name: "channelName",
   url: "channelUrl",
+  user: [mockDBUserValue],
+  message: [mockDbMessageValue],
+  message_reaction: [],
 };
 
 export const mockChannelEntityValue = {
@@ -141,6 +145,9 @@ export const mockChannelEntityValue = {
   name: "channelName",
   url: "channelUrl",
   createdAt: mockDbChannelValue.created_at, // ou new Date() se preferir um novo objeto
+  user: [mockUserValue],
+  message: [mockMessageValue],
+  messageReaction: [],
 };
 
 export const mockChannelUpdatePayload = {

--- a/src/tests/messageReaction/repository.test.ts
+++ b/src/tests/messageReaction/repository.test.ts
@@ -33,6 +33,7 @@ const mockDbUser: User = {
   bot: false,
   email: "test@test.com",
   status: 1,
+  channelId: null,
 };
 
 const mockDbMessage: Message = {


### PR DESCRIPTION
## Descrição
Associar a entidade `Channel` à `User`, `Message` e `MessageReaction`
[CPDD-274](https://www.notion.so/cpdd/Check-in-Online-e61948851da14ce3b96b99f567b8baee?p=212c5f6d25f8806199caecafa4c7a7ae&pm=s)

## Tipo de mudança
- [ ] Bugfix
- [x] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação 

## Checklist
- [x]  Associar as entidade mencionadas.
- [x]  Atualizar testes para refletir as alterações.
- [x]  Atualizar as interfaces para refletir a associação.
- [x]  Atualizar repositório para refletir essas associações (Se necessário).