### PR TITLE
Mudança no comando do compose para melhorar o fluxo de get started

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,16 +1,17 @@
+version: "3.9"
+
 services:
   db:
     image: mariadb:latest
     restart: always
     environment:
-      MYSQL_DATABASE: '${DB_DATABASE}'
-      MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
-      TZ: 'UTC'
-
+      MYSQL_DATABASE: "${DB_DATABASE}"
+      MYSQL_ROOT_PASSWORD: "${DB_PASSWORD}"
+      TZ: "UTC"
     volumes:
       - db_data:/var/lib/mysql
     healthcheck:
-      test: [ "CMD", "healthcheck.sh", "--connect", "--innodb_initialized" ]
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 10s
       timeout: 10s
       retries: 10
@@ -20,36 +21,32 @@ services:
     image: phpmyadmin/phpmyadmin
     ports:
       - "8090:80"
-    links:
-      - db
     environment:
-      - PMA_HOST=db
-      - UPLOAD_LIMIT=300M
+      PMA_HOST: db
+      UPLOAD_LIMIT: 300M
     depends_on:
       db:
         condition: service_healthy
-    profiles:
-      - dev
+    profiles: ["dev"]
 
   app:
     build:
       context: .
-
       dockerfile: ./Containerfile
     container_name: node_app
     restart: always
     ports:
       - "${PORT}:3000"
+    env_file:
+      - .env
     volumes:
-      - ./.env:/opt/checkin-app/.env  # Monta o .env da root.
+      - ./.env:/opt/checkin-app/.env
     depends_on:
       db:
         condition: service_healthy
     command: >
       sh -c "npx prisma migrate deploy && npm start"
-    profiles:
-      - prod
-      - homol
+    profiles: ["dev", "prod", "homol"]
 
 volumes:
   db_data:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc && tsc-alias",
     "start": "tsc && tsc-alias && node dist/index.js",
-    "dev": "docker compose --profile dev up -d && npx prisma generate && npx prisma migrate dev && nodemon --exec ts-node ./src/index.ts",
+    "dev": "docker compose --profile dev up -d --build && docker compose logs -f app",
     "prod": "docker compose -f compose.yml --profile prod up -d --build",
     "worker": "tsc && pm2 start dist/index.js --no-daemon",
     "heroku-postbuild": "npm install pm2 --save",

--- a/src/tests/config/constants.ts
+++ b/src/tests/config/constants.ts
@@ -187,7 +187,7 @@ export const mockDbAudioEventValue = {
 export const mockAudioEventEntityValue = AudioEventEntity.fromPersistence(
   mockDbAudioEventValue,
   mockDbChannelValue,
-  mockDBUserValue
+  mockDBUserValue,
 );
 
 export const mockAudioEventCreatePayload: Omit<
@@ -195,7 +195,7 @@ export const mockAudioEventCreatePayload: Omit<
   "id" | "createdAt"
 > = {
   platformId: "1234567890",
-  channel: mockChannelEntityValue,
+  channel: mockChannelEntityValue as never,
   creator: mockUserValue,
   name: "New Event",
   description: "A brand new event",


### PR DESCRIPTION
Coloquei os comandos de inicialização do prisma deploy e start dentro do compose.yml para que o serviço já suba com tudo pronto.