### PR TITLE
Feature/cpdd 241 channel usecases

### DIFF
--- a/src/application/command/channelCommand.ts
+++ b/src/application/command/channelCommand.ts
@@ -111,7 +111,7 @@ export class ChannelCommand implements IChannelCommand {
     await this.deleteChannel.execute(channel.id);
   }
 
-  private static toChannelCreateEntity(
+  public static toChannelCreateEntity(
     discordChannel: GuildChannel,
   ): CreateChannelType {
     return {

--- a/src/application/command/channelCommand.ts
+++ b/src/application/command/channelCommand.ts
@@ -1,0 +1,158 @@
+import { IChannelCommand } from "@domain/interfaces/commands/IChannelCommand";
+import { IDiscordService } from "@domain/interfaces/services/IDiscordService";
+import { ILoggerService } from "@domain/interfaces/services/ILogger";
+import {
+  CreateChannelType,
+  ICreateChannel,
+} from "@domain/interfaces/useCases/channel/ICreateChannel";
+import { IDeleteChannel } from "@domain/interfaces/useCases/channel/IDeleteChannel";
+import { IUpdateChannel } from "@domain/interfaces/useCases/channel/IUpdateChannel";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "@domain/types/LoggerContextEnum";
+import {
+  Client,
+  Events,
+  GuildChannel,
+  GuildMember,
+  Message,
+  PartialGuildMember,
+  PermissionsBitField,
+} from "discord.js";
+
+export class ChannelCommand implements IChannelCommand {
+  constructor(
+    private readonly discordService: IDiscordService<
+      Message,
+      GuildMember,
+      PartialGuildMember,
+      Client
+    >,
+    private readonly logger: ILoggerService,
+    private readonly createChannel: ICreateChannel,
+    private readonly updateChannel: IUpdateChannel,
+    private readonly deleteChannel: IDeleteChannel,
+  ) {
+    this.handleCreateChannel();
+    this.handleUpdateChannel();
+    this.handleDeleteChannel();
+  }
+
+  private get discordClient(): Client {
+    return this.discordService.client;
+  }
+
+  public async handleCreateChannel(): Promise<void> {
+    try {
+      this.discordClient.on(
+        Events.ChannelCreate,
+        this.onChannelCreated.bind(this),
+      );
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.CHANNEL,
+        `Fail to create channel, \ncause:\n ${error.message}`,
+      );
+    }
+  }
+
+  public async handleUpdateChannel(): Promise<void> {
+    try {
+      this.discordClient.on(
+        Events.ChannelUpdate,
+        this.onChannelUpdated.bind(this),
+      );
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.CHANNEL,
+        `Fail to update channel, \ncause:\n ${error.message}`,
+      );
+    }
+  }
+
+  public async handleDeleteChannel(): Promise<void> {
+    try {
+      this.discordClient.on(
+        Events.ChannelDelete,
+        this.onChannelDeleted.bind(this),
+      );
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.CHANNEL,
+        `Fail to delete channel, \ncause:\n ${error.message}`,
+      );
+    }
+  }
+
+  private async onChannelCreated(channel: GuildChannel): Promise<void> {
+    this.checkIfBotHasChannelPermissions(channel);
+    await this.createChannel.execute(
+      ChannelCommand.toChannelCreateEntity(channel),
+    );
+  }
+
+  private async onChannelUpdated(channel: GuildChannel): Promise<void> {
+    this.checkIfBotHasChannelPermissions(channel);
+    await this.updateChannel.execute(
+      channel.id,
+      ChannelCommand.toChannelCreateEntity(channel),
+    );
+  }
+
+  private async onChannelDeleted(channel: GuildChannel): Promise<void> {
+    this.checkIfBotHasChannelPermissions(channel);
+    await this.deleteChannel.execute(channel.id);
+  }
+
+  private checkIfBotHasChannelPermissions(channel: GuildChannel): void {
+    if (!channel.guild) {
+      console.log("❌ Canal não pertence a uma guild");
+      return;
+    }
+
+    const botMember = channel.guild.members.cache.get(
+      this.discordClient.user.id,
+    );
+    if (!botMember) {
+      console.log("❌ Bot member não encontrado na guild do canal");
+      return;
+    }
+
+    const requiredPermissions = [
+      PermissionsBitField.Flags.ViewChannel,
+      PermissionsBitField.Flags.SendMessages,
+      PermissionsBitField.Flags.ManageChannels,
+    ];
+
+    const hasPermissions = requiredPermissions.every((permission) =>
+      channel.permissionsFor(botMember).has(permission),
+    );
+
+    if (!hasPermissions) {
+      console.log("❌ Bot falta permissões no canal:");
+      requiredPermissions.forEach((permission) => {
+        const hasPerm = channel.permissionsFor(botMember).has(permission);
+        console.log(`   ${hasPerm ? "✅" : "❌"} ${permission}`);
+      });
+    }
+  }
+
+  private static toChannelCreateEntity(
+    discordChannel: GuildChannel,
+  ): CreateChannelType {
+    return {
+      platformId: discordChannel.id,
+      name: discordChannel.name,
+      url: discordChannel.url,
+      createdAt: discordChannel.createdAt,
+    };
+  }
+}

--- a/src/application/command/channelCommand.ts
+++ b/src/application/command/channelCommand.ts
@@ -14,7 +14,6 @@ import {
 } from "@domain/types/LoggerContextEnum";
 import {
   Client,
-  Events,
   GuildChannel,
   GuildMember,
   Message,
@@ -45,10 +44,7 @@ export class ChannelCommand implements IChannelCommand {
 
   public async handleCreateChannel(): Promise<void> {
     try {
-      this.discordClient.on(
-        Events.ChannelCreate,
-        this.onChannelCreated.bind(this),
-      );
+      this.discordService.onCreateChannel(this.onChannelCreated.bind(this));
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
@@ -61,10 +57,7 @@ export class ChannelCommand implements IChannelCommand {
 
   public async handleUpdateChannel(): Promise<void> {
     try {
-      this.discordClient.on(
-        Events.ChannelUpdate,
-        this.onChannelUpdated.bind(this),
-      );
+      this.discordService.onChangeChannel(this.onChannelUpdated.bind(this));
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
@@ -77,10 +70,7 @@ export class ChannelCommand implements IChannelCommand {
 
   public async handleDeleteChannel(): Promise<void> {
     try {
-      this.discordClient.on(
-        Events.ChannelDelete,
-        this.onChannelDeleted.bind(this),
-      );
+      this.discordService.onDeleteChannel(this.onChannelDeleted.bind(this));
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,

--- a/src/application/command/channelCommand.ts
+++ b/src/application/command/channelCommand.ts
@@ -38,10 +38,6 @@ export class ChannelCommand implements IChannelCommand {
     this.handleDeleteChannel();
   }
 
-  private get discordClient(): Client {
-    return this.discordService.client;
-  }
-
   public async handleCreateChannel(): Promise<void> {
     try {
       this.discordService.onCreateChannel(this.onChannelCreated.bind(this));

--- a/src/application/command/channelCommand.ts
+++ b/src/application/command/channelCommand.ts
@@ -19,7 +19,6 @@ import {
   GuildMember,
   Message,
   PartialGuildMember,
-  PermissionsBitField,
 } from "discord.js";
 
 export class ChannelCommand implements IChannelCommand {
@@ -93,56 +92,23 @@ export class ChannelCommand implements IChannelCommand {
   }
 
   private async onChannelCreated(channel: GuildChannel): Promise<void> {
-    this.checkIfBotHasChannelPermissions(channel);
     await this.createChannel.execute(
       ChannelCommand.toChannelCreateEntity(channel),
     );
   }
 
-  private async onChannelUpdated(channel: GuildChannel): Promise<void> {
-    this.checkIfBotHasChannelPermissions(channel);
+  private async onChannelUpdated(
+    _oldChannel: GuildChannel,
+    newChannel: GuildChannel,
+  ): Promise<void> {
     await this.updateChannel.execute(
-      channel.id,
-      ChannelCommand.toChannelCreateEntity(channel),
+      newChannel.id,
+      ChannelCommand.toChannelCreateEntity(newChannel),
     );
   }
 
   private async onChannelDeleted(channel: GuildChannel): Promise<void> {
-    this.checkIfBotHasChannelPermissions(channel);
     await this.deleteChannel.execute(channel.id);
-  }
-
-  private checkIfBotHasChannelPermissions(channel: GuildChannel): void {
-    if (!channel.guild) {
-      console.log("❌ Canal não pertence a uma guild");
-      return;
-    }
-
-    const botMember = channel.guild.members.cache.get(
-      this.discordClient.user.id,
-    );
-    if (!botMember) {
-      console.log("❌ Bot member não encontrado na guild do canal");
-      return;
-    }
-
-    const requiredPermissions = [
-      PermissionsBitField.Flags.ViewChannel,
-      PermissionsBitField.Flags.SendMessages,
-      PermissionsBitField.Flags.ManageChannels,
-    ];
-
-    const hasPermissions = requiredPermissions.every((permission) =>
-      channel.permissionsFor(botMember).has(permission),
-    );
-
-    if (!hasPermissions) {
-      console.log("❌ Bot falta permissões no canal:");
-      requiredPermissions.forEach((permission) => {
-        const hasPerm = channel.permissionsFor(botMember).has(permission);
-        console.log(`   ${hasPerm ? "✅" : "❌"} ${permission}`);
-      });
-    }
   }
 
   private static toChannelCreateEntity(

--- a/src/application/command/voiceEventCommand.ts
+++ b/src/application/command/voiceEventCommand.ts
@@ -2,6 +2,7 @@
 
 import {
   Client,
+  GuildChannel,
   GuildScheduledEvent,
   PartialGuildScheduledEvent,
 } from "discord.js";
@@ -25,6 +26,7 @@ export class VoiceEventCommand {
       unknown,
       unknown,
       Client,
+      GuildChannel,
       GuildScheduledEvent | PartialGuildScheduledEvent
     >,
     private readonly logger: ILoggerService,

--- a/src/contexts/app.context.ts
+++ b/src/contexts/app.context.ts
@@ -1,19 +1,21 @@
-import { initializeDatabase } from "./database.context";
-import { initializeUserUseCases } from "./useUserCases.context";
-import { initializeDiscord } from "./discord.context";
+import { ChannelCommand } from "@application/command/channelCommand";
 import { UserCommand } from "@application/command/userCommand";
 import { Logger } from "@application/services/Logger";
+import { ErrorMessages } from "@type/ErrorMessages";
 import {
-  LoggerContextStatus,
   LoggerContext,
   LoggerContextEntity,
+  LoggerContextStatus,
 } from "@type/LoggerContextEnum";
-import { ErrorMessages } from "@type/ErrorMessages";
+import { initializeDatabase } from "./database.context";
+import { initializeDiscord } from "./discord.context";
+import { initializeChannelUseCases } from "./useChannelCases.context";
+import { initializeUserUseCases } from "./useUserCases.context";
 
 export function initializeApp() {
   // Aqui vao as dependencias externas
   const logger = new Logger();
-  const { userRepository } = initializeDatabase(logger);
+  const { userRepository, channelRepository } = initializeDatabase(logger);
   const { discordService } = initializeDiscord();
   const { TOKEN_BOT } = process.env;
 
@@ -39,4 +41,13 @@ export function initializeApp() {
   // Isso deve ser executado depois que o user command for iniciado
   discordService.registerEvents();
   discordService.client.login(TOKEN_BOT);
+
+  const channelUseCases = initializeChannelUseCases(channelRepository, logger);
+  new ChannelCommand(
+    discordService,
+    logger,
+    channelUseCases.createChannelCase,
+    channelUseCases.updateChannelCase,
+    channelUseCases.deleteChannelCase,
+  );
 }

--- a/src/contexts/useChannelCases.context.ts
+++ b/src/contexts/useChannelCases.context.ts
@@ -1,0 +1,19 @@
+import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepository";
+import { CreateChannel } from "@domain/useCases/channel/CreateChannel";
+import { DeleteChannel } from "@domain/useCases/channel/DeleteChannel";
+import { UpdateChannel } from "@domain/useCases/channel/UpdateChannel";
+import { ILoggerService } from "@services/ILogger";
+
+export const initializeChannelUseCases = (
+  channelRepository: IChannelRepository,
+  logger: ILoggerService,
+) => {
+  const createChannelCase = new CreateChannel(channelRepository, logger);
+  const updateChannelCase = new UpdateChannel(channelRepository, logger);
+  const deleteChannelCase = new DeleteChannel(channelRepository, logger);
+  return {
+    createChannelCase,
+    updateChannelCase,
+    deleteChannelCase,
+  };
+};

--- a/src/domain/interfaces/commands/IChannelCommand.ts
+++ b/src/domain/interfaces/commands/IChannelCommand.ts
@@ -1,0 +1,5 @@
+export interface IChannelCommand {
+  handleCreateChannel(): Promise<void>;
+  handleUpdateChannel(): Promise<void>;
+  handleDeleteChannel(): Promise<void>;
+}

--- a/src/domain/interfaces/repositories/IChannelRepository.ts
+++ b/src/domain/interfaces/repositories/IChannelRepository.ts
@@ -1,7 +1,6 @@
 import { ChannelEntity } from "../../entities/Channel";
 
 export interface IChannelRepository {
-  createMinimal(channel: Omit<ChannelEntity, "id">): Promise<ChannelEntity>;
   create(voiceChannel: Omit<ChannelEntity, "id">): Promise<ChannelEntity>;
   createMany(voiceChannels: Omit<ChannelEntity, "id">[]): Promise<number>;
   findById(

--- a/src/domain/interfaces/repositories/IChannelRepository.ts
+++ b/src/domain/interfaces/repositories/IChannelRepository.ts
@@ -1,6 +1,7 @@
 import { ChannelEntity } from "../../entities/Channel";
 
 export interface IChannelRepository {
+  createMinimal(channel: Omit<ChannelEntity, "id">): Promise<ChannelEntity>;
   create(voiceChannel: Omit<ChannelEntity, "id">): Promise<ChannelEntity>;
   createMany(voiceChannels: Omit<ChannelEntity, "id">[]): Promise<number>;
   findById(

--- a/src/domain/interfaces/services/IDiscordService.ts
+++ b/src/domain/interfaces/services/IDiscordService.ts
@@ -2,7 +2,8 @@ export interface IDiscordService<
   M = unknown,
   U = unknown,
   P = unknown,
-  T = unknown
+  T = unknown,
+  C = unknown,
 > {
   client: T;
   onDiscordStart(handler: () => void): void;
@@ -10,4 +11,7 @@ export interface IDiscordService<
   onNewUser(handler: (member: U) => void): void;
   onUserLeave(handler: (member: U | P) => void): void;
   registerEvents(): void;
+  onCreateChannel(handler: (channel: C) => void): void;
+  onChangeChannel(handler: (oldChannel: C, newChannel: C) => void): void;
+  onDeleteChannel(handler: (channel: C) => void): void;
 }

--- a/src/domain/interfaces/useCases/channel/IChannelId.ts
+++ b/src/domain/interfaces/useCases/channel/IChannelId.ts
@@ -1,0 +1,1 @@
+export type ChannelIdType = number | string;

--- a/src/domain/interfaces/useCases/channel/ICreateChannel.ts
+++ b/src/domain/interfaces/useCases/channel/ICreateChannel.ts
@@ -1,0 +1,8 @@
+import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
+import { ChannelEntity } from "@domain/entities/Channel";
+
+export type CreateChannelType = Omit<ChannelEntity, "id">;
+
+export interface ICreateChannel {
+  execute(channel: CreateChannelType): Promise<GenericOutputDto<ChannelEntity>>;
+}

--- a/src/domain/interfaces/useCases/channel/ICreateChannel.ts
+++ b/src/domain/interfaces/useCases/channel/ICreateChannel.ts
@@ -1,8 +1,7 @@
-import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
 import { ChannelEntity } from "@domain/entities/Channel";
 
 export type CreateChannelType = Omit<ChannelEntity, "id">;
 
 export interface ICreateChannel {
-  execute(channel: CreateChannelType): Promise<GenericOutputDto<ChannelEntity>>;
+  execute(channel: CreateChannelType): Promise<void>;
 }

--- a/src/domain/interfaces/useCases/channel/IDeleteChannel.ts
+++ b/src/domain/interfaces/useCases/channel/IDeleteChannel.ts
@@ -1,0 +1,6 @@
+import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
+import { ChannelIdType } from "./IChannelId";
+
+export interface IDeleteChannel {
+  execute(id: ChannelIdType): Promise<GenericOutputDto<boolean>>;
+}

--- a/src/domain/interfaces/useCases/channel/IDeleteChannel.ts
+++ b/src/domain/interfaces/useCases/channel/IDeleteChannel.ts
@@ -1,6 +1,5 @@
-import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
 import { ChannelIdType } from "./IChannelId";
 
 export interface IDeleteChannel {
-  execute(id: ChannelIdType): Promise<GenericOutputDto<boolean>>;
+  execute(id: ChannelIdType): Promise<void>;
 }

--- a/src/domain/interfaces/useCases/channel/IUpdateChannel.ts
+++ b/src/domain/interfaces/useCases/channel/IUpdateChannel.ts
@@ -1,0 +1,10 @@
+import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
+import { ChannelEntity } from "@domain/entities/Channel";
+import { ChannelIdType } from "./IChannelId";
+
+export interface IUpdateChannel {
+  execute(
+    id: ChannelIdType,
+    data: Partial<ChannelEntity>,
+  ): Promise<GenericOutputDto<ChannelEntity>>;
+}

--- a/src/domain/interfaces/useCases/channel/IUpdateChannel.ts
+++ b/src/domain/interfaces/useCases/channel/IUpdateChannel.ts
@@ -1,10 +1,6 @@
-import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
 import { ChannelEntity } from "@domain/entities/Channel";
 import { ChannelIdType } from "./IChannelId";
 
 export interface IUpdateChannel {
-  execute(
-    id: ChannelIdType,
-    data: Partial<ChannelEntity>,
-  ): Promise<GenericOutputDto<ChannelEntity>>;
+  execute(id: ChannelIdType, data: Partial<ChannelEntity>): Promise<void>;
 }

--- a/src/domain/types/ErrorMessages.ts
+++ b/src/domain/types/ErrorMessages.ts
@@ -4,4 +4,5 @@ export enum ErrorMessages {
   USER_ALREADY_EXISTS = "User already exists",
   UNKNOWN_ERROR = "Unknown error occurred",
   MISSING_SECRET = "Secret key not found",
+  CHANNEL_NOT_FOUND = "Channel not found with id",
 }

--- a/src/domain/useCases/channel/CreateChannel.ts
+++ b/src/domain/useCases/channel/CreateChannel.ts
@@ -1,0 +1,41 @@
+import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
+import { ChannelEntity } from "@domain/entities/Channel";
+import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepository";
+import { ILoggerService } from "@domain/interfaces/services/ILogger";
+import {
+  CreateChannelType,
+  ICreateChannel,
+} from "@domain/interfaces/useCases/channel/ICreateChannel";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "@domain/types/LoggerContextEnum";
+
+export class CreateChannel implements ICreateChannel {
+  constructor(
+    private readonly channelRepository: IChannelRepository,
+    private readonly logger: ILoggerService,
+  ) {}
+
+  public async execute(
+    channel: CreateChannelType,
+  ): Promise<GenericOutputDto<ChannelEntity>> {
+    try {
+      const createdChannel =
+        await this.channelRepository.createMinimal(channel);
+      return {
+        data: { ...createdChannel },
+        success: true,
+        message: "Channel saved successfully",
+      };
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.USER,
+        `executeCreateChannel | ${error.message}`,
+      );
+    }
+  }
+}

--- a/src/domain/useCases/channel/CreateChannel.ts
+++ b/src/domain/useCases/channel/CreateChannel.ts
@@ -22,8 +22,7 @@ export class CreateChannel implements ICreateChannel {
     channel: CreateChannelType,
   ): Promise<GenericOutputDto<ChannelEntity>> {
     try {
-      const createdChannel =
-        await this.channelRepository.createMinimal(channel);
+      const createdChannel = await this.channelRepository.create(channel);
       return {
         data: { ...createdChannel },
         success: true,

--- a/src/domain/useCases/channel/CreateChannel.ts
+++ b/src/domain/useCases/channel/CreateChannel.ts
@@ -1,5 +1,3 @@
-import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
-import { ChannelEntity } from "@domain/entities/Channel";
 import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepository";
 import { ILoggerService } from "@domain/interfaces/services/ILogger";
 import {
@@ -18,21 +16,20 @@ export class CreateChannel implements ICreateChannel {
     private readonly logger: ILoggerService,
   ) {}
 
-  public async execute(
-    channel: CreateChannelType,
-  ): Promise<GenericOutputDto<ChannelEntity>> {
+  public async execute(channel: CreateChannelType): Promise<void> {
     try {
       const createdChannel = await this.channelRepository.create(channel);
-      return {
-        data: { ...createdChannel },
-        success: true,
-        message: "Channel saved successfully",
-      };
+      this.logger.logToConsole(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Channel ${createdChannel.id} - ${createdChannel.name} saved successfully`,
+      );
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
-        LoggerContext.COMMAND,
-        LoggerContextEntity.USER,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
         `executeCreateChannel | ${error.message}`,
       );
     }

--- a/src/domain/useCases/channel/DeleteChannel.ts
+++ b/src/domain/useCases/channel/DeleteChannel.ts
@@ -1,0 +1,53 @@
+import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
+import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepository";
+import { ILoggerService } from "@domain/interfaces/services/ILogger";
+import { ChannelIdType } from "@domain/interfaces/useCases/channel/IChannelId";
+import { IDeleteChannel } from "@domain/interfaces/useCases/channel/IDeleteChannel";
+import { ErrorMessages } from "@domain/types/ErrorMessages";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "@domain/types/LoggerContextEnum";
+
+export class DeleteChannel implements IDeleteChannel {
+  constructor(
+    private readonly channelRepository: IChannelRepository,
+    private readonly logger: ILoggerService,
+  ) {}
+
+  public async execute(id: ChannelIdType): Promise<GenericOutputDto<boolean>> {
+    try {
+      const channel =
+        typeof id === "string"
+          ? await this.channelRepository.findByPlatformId(id)
+          : await this.channelRepository.findById(id);
+
+      if (!channel) {
+        return {
+          data: null,
+          success: false,
+          message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
+        };
+      }
+
+      const isDeleted = await this.channelRepository.deleteById(channel.id);
+      return {
+        data: isDeleted,
+        success: true,
+      };
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.USECASE,
+        LoggerContextEntity.USER,
+        `DeleteChannel.execute | ${error.message}`,
+      );
+      return {
+        data: false,
+        success: false,
+        message: error.message,
+      };
+    }
+  }
+}

--- a/src/domain/useCases/channel/DeleteChannel.ts
+++ b/src/domain/useCases/channel/DeleteChannel.ts
@@ -40,7 +40,7 @@ export class DeleteChannel implements IDeleteChannel {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
         LoggerContext.USECASE,
-        LoggerContextEntity.USER,
+        LoggerContextEntity.CHANNEL,
         `DeleteChannel.execute | ${error.message}`,
       );
       return {

--- a/src/domain/useCases/channel/DeleteChannel.ts
+++ b/src/domain/useCases/channel/DeleteChannel.ts
@@ -1,4 +1,3 @@
-import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
 import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepository";
 import { ILoggerService } from "@domain/interfaces/services/ILogger";
 import { ChannelIdType } from "@domain/interfaces/useCases/channel/IChannelId";
@@ -16,7 +15,7 @@ export class DeleteChannel implements IDeleteChannel {
     private readonly logger: ILoggerService,
   ) {}
 
-  public async execute(id: ChannelIdType): Promise<GenericOutputDto<boolean>> {
+  public async execute(id: ChannelIdType): Promise<void> {
     try {
       const channel =
         typeof id === "string"
@@ -24,18 +23,21 @@ export class DeleteChannel implements IDeleteChannel {
           : await this.channelRepository.findById(id);
 
       if (!channel) {
-        return {
-          data: null,
-          success: false,
-          message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
-        };
+        this.logger.logToConsole(
+          LoggerContextStatus.ERROR,
+          LoggerContext.USECASE,
+          LoggerContextEntity.CHANNEL,
+          `DeleteChannel.execute | ${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
+        );
       }
 
       const isDeleted = await this.channelRepository.deleteById(channel.id);
-      return {
-        data: isDeleted,
-        success: true,
-      };
+      this.logger.logToConsole(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Was channel ${channel.id} - ${channel.name} deleted: ${isDeleted}`,
+      );
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
@@ -43,11 +45,6 @@ export class DeleteChannel implements IDeleteChannel {
         LoggerContextEntity.CHANNEL,
         `DeleteChannel.execute | ${error.message}`,
       );
-      return {
-        data: false,
-        success: false,
-        message: error.message,
-      };
     }
   }
 }

--- a/src/domain/useCases/channel/UpdateChannel.ts
+++ b/src/domain/useCases/channel/UpdateChannel.ts
@@ -48,7 +48,7 @@ export class UpdateChannel implements IUpdateChannel {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
         LoggerContext.USECASE,
-        LoggerContextEntity.USER,
+        LoggerContextEntity.CHANNEL,
         `UpdateChannel.execute | ${error.message}`,
       );
       return {

--- a/src/domain/useCases/channel/UpdateChannel.ts
+++ b/src/domain/useCases/channel/UpdateChannel.ts
@@ -1,0 +1,60 @@
+import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
+import { ChannelEntity } from "@domain/entities/Channel";
+import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepository";
+import { ILoggerService } from "@domain/interfaces/services/ILogger";
+import { ChannelIdType } from "@domain/interfaces/useCases/channel/IChannelId";
+import { IUpdateChannel } from "@domain/interfaces/useCases/channel/IUpdateChannel";
+import { ErrorMessages } from "@domain/types/ErrorMessages";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "@domain/types/LoggerContextEnum";
+
+export class UpdateChannel implements IUpdateChannel {
+  constructor(
+    private readonly channelRepository: IChannelRepository,
+    private readonly logger: ILoggerService,
+  ) {}
+
+  public async execute(
+    id: ChannelIdType,
+    data: Partial<ChannelEntity>,
+  ): Promise<GenericOutputDto<ChannelEntity>> {
+    try {
+      const channel =
+        typeof id === "string"
+          ? await this.channelRepository.findByPlatformId(id)
+          : await this.channelRepository.findById(id);
+
+      if (!channel) {
+        return {
+          data: null,
+          success: false,
+          message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
+        };
+      }
+
+      const updatedChannel = await this.channelRepository.updateById(
+        channel.id,
+        data,
+      );
+      return {
+        data: { ...updatedChannel },
+        success: true,
+      };
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.USECASE,
+        LoggerContextEntity.USER,
+        `UpdateChannel.execute | ${error.message}`,
+      );
+      return {
+        data: null,
+        success: false,
+        message: error.message,
+      };
+    }
+  }
+}

--- a/src/domain/useCases/channel/UpdateChannel.ts
+++ b/src/domain/useCases/channel/UpdateChannel.ts
@@ -1,4 +1,3 @@
-import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
 import { ChannelEntity } from "@domain/entities/Channel";
 import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepository";
 import { ILoggerService } from "@domain/interfaces/services/ILogger";
@@ -20,7 +19,7 @@ export class UpdateChannel implements IUpdateChannel {
   public async execute(
     id: ChannelIdType,
     data: Partial<ChannelEntity>,
-  ): Promise<GenericOutputDto<ChannelEntity>> {
+  ): Promise<void> {
     try {
       const channel =
         typeof id === "string"
@@ -28,11 +27,12 @@ export class UpdateChannel implements IUpdateChannel {
           : await this.channelRepository.findById(id);
 
       if (!channel) {
-        return {
-          data: null,
-          success: false,
-          message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
-        };
+        this.logger.logToConsole(
+          LoggerContextStatus.ERROR,
+          LoggerContext.USECASE,
+          LoggerContextEntity.CHANNEL,
+          `UpdateChannel.execute | ${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
+        );
       }
 
       const updatedChannel = await this.channelRepository.updateById(
@@ -40,10 +40,12 @@ export class UpdateChannel implements IUpdateChannel {
         data,
       );
 
-      return {
-        data: { ...updatedChannel },
-        success: true,
-      };
+      this.logger.logToConsole(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Channel ${updatedChannel.id} - ${updatedChannel.name} has been updated`,
+      );
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
@@ -51,11 +53,6 @@ export class UpdateChannel implements IUpdateChannel {
         LoggerContextEntity.CHANNEL,
         `UpdateChannel.execute | ${error.message}`,
       );
-      return {
-        data: null,
-        success: false,
-        message: error.message,
-      };
     }
   }
 }

--- a/src/domain/useCases/channel/UpdateChannel.ts
+++ b/src/domain/useCases/channel/UpdateChannel.ts
@@ -39,6 +39,7 @@ export class UpdateChannel implements IUpdateChannel {
         channel.id,
         data,
       );
+
       return {
         data: { ...updatedChannel },
         success: true,

--- a/src/infrastructure/persistence/repositories/ChannelRepository.ts
+++ b/src/infrastructure/persistence/repositories/ChannelRepository.ts
@@ -22,10 +22,10 @@ export class ChannelRepository implements IChannelRepository {
   }
 
   /**
-   * Cria um novo usuario no banco de dados.
+   * Cria um novo canal no banco de dados.
    *
-   * @param {Omit<ChannelEntity, "id">} channel Os dados do usuario a ser criado.
-   * @returns {Promise<ChannelEntity>} O usuario criado.
+   * @param {Omit<ChannelEntity, "id">} channel Os dados do canal a ser criado.
+   * @returns {Promise<ChannelEntity>} O canal criado.
    */
   async create(channel: Omit<ChannelEntity, "id">): Promise<ChannelEntity> {
     try {
@@ -33,12 +33,12 @@ export class ChannelRepository implements IChannelRepository {
         data: {
           ...this.toPersistence(channel),
           message: {
-            connect: channel.message.map((message) => ({
+            connect: channel?.message.map((message) => ({
               platform_id: message.platformId,
             })),
           },
           message_reaction: {
-            connect: channel.messageReaction.map((messageReaction) => ({
+            connect: channel?.messageReaction.map((messageReaction) => ({
               id: messageReaction.id,
             })),
           },
@@ -71,6 +71,36 @@ export class ChannelRepository implements IChannelRepository {
         LoggerContext.REPOSITORY,
         LoggerContextEntity.CHANNEL,
         `create | ${error.message}`,
+      );
+      return null;
+    }
+  }
+
+  public async createMinimal(
+    channel: Omit<ChannelEntity, "id">,
+  ): Promise<ChannelEntity> {
+    try {
+      const persistenceChannel = this.toPersistence(channel);
+      const result = await this.client.channel.create({
+        data: { ...persistenceChannel },
+        include: {
+          message: false,
+          message_reaction: false,
+          user_channel: {
+            include: { user: true },
+          },
+        },
+      });
+      return ChannelEntity.fromPersistence(
+        result,
+        result.user_channel?.map((uc) => uc.user) || [],
+      );
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.CHANNEL,
+        `createMinimal | ${error.message}`,
       );
       return null;
     }
@@ -134,10 +164,10 @@ export class ChannelRepository implements IChannelRepository {
   }
 
   /**
-   * Retorna um usuario pelo id.
+   * Retorna um canal pelo id.
    *
-   * @param {number} id O id do usuario a ser buscado.
-   * @returns {Promise<ChannelEntity | null>} O usuario encontrado. Se o usuario nao existir, retorna null.
+   * @param {number} id O id do canal a ser buscado.
+   * @returns {Promise<ChannelEntity | null>} O canal encontrado. Se o canal nao existir, retorna null.
    */
   async findById(id: number): Promise<ChannelEntity | null> {
     try {
@@ -174,10 +204,10 @@ export class ChannelRepository implements IChannelRepository {
   }
 
   /**
-   * Retorna um usuario pelo id do Discord.
+   * Retorna um canal pelo id do Discord.
    *
-   * @param {string} id O id do Discord do usuario a ser buscado.
-   * @returns {Promise<ChannelEntity | null>} O usuario encontrado. Se o usuario nao existir, retorna null.
+   * @param {string} id O id do Discord do canal a ser buscado.
+   * @returns {Promise<ChannelEntity | null>} O canal encontrado. Se o canal nao existir, retorna null.
    */
   async findByPlatformId(id: string): Promise<ChannelEntity | null> {
     try {
@@ -212,10 +242,10 @@ export class ChannelRepository implements IChannelRepository {
   }
 
   /**
-   * Retorna uma lista de usuarios.
+   * Retorna uma lista de canais.
    *
-   * @param {number} [limit] O limite de usuarios a serem retornados.
-   * @returns {Promise<ChannelEntity[]>} A lista de usuarios.
+   * @param {number} [limit] O limite de canais a serem retornados.
+   * @returns {Promise<ChannelEntity[]>} A lista de canais.
    */
   async listAll(limit?: number): Promise<ChannelEntity[]> {
     try {
@@ -249,11 +279,11 @@ export class ChannelRepository implements IChannelRepository {
   }
 
   /**
-   * Atualiza um usuario pelo id.
+   * Atualiza um canal pelo id.
    *
-   * @param {number} id O id do usuario a ser atualizado.
-   * @param {ChannelEntity} channel Os dados do usuario a ser atualizado.
-   * @returns {Promise<ChannelEntity | null>} O usuario atualizado. Se o usuario nao existir, retorna null.
+   * @param {number} id O id do canal a ser atualizado.
+   * @param {ChannelEntity} channel Os dados do canal a ser atualizado.
+   * @returns {Promise<ChannelEntity | null>} O canal atualizado. Se o canal nao existir, retorna null.
    */
   async updateById(
     id: number,
@@ -276,10 +306,10 @@ export class ChannelRepository implements IChannelRepository {
   }
 
   /**
-   * Deleta um usuario pelo id.
+   * Deleta um canal pelo id.
    *
-   * @param {number} id O id do usuario a ser deletado.
-   * @returns {Promise<boolean>} True se o usuario foi deletado, false caso contrario.
+   * @param {number} id O id do canal a ser deletado.
+   * @returns {Promise<boolean>} True se o canal foi deletado, false caso contrario.
    */
   async deleteById(id: number): Promise<boolean> {
     try {

--- a/src/infrastructure/persistence/repositories/ChannelRepository.ts
+++ b/src/infrastructure/persistence/repositories/ChannelRepository.ts
@@ -33,12 +33,12 @@ export class ChannelRepository implements IChannelRepository {
         data: {
           ...this.toPersistence(channel),
           message: {
-            connect: channel?.message.map((message) => ({
+            connect: channel?.message?.map((message) => ({
               platform_id: message.platformId,
             })),
           },
           message_reaction: {
-            connect: channel?.messageReaction.map((messageReaction) => ({
+            connect: channel?.messageReaction?.map((messageReaction) => ({
               id: messageReaction.id,
             })),
           },
@@ -71,36 +71,6 @@ export class ChannelRepository implements IChannelRepository {
         LoggerContext.REPOSITORY,
         LoggerContextEntity.CHANNEL,
         `create | ${error.message}`,
-      );
-      return null;
-    }
-  }
-
-  public async createMinimal(
-    channel: Omit<ChannelEntity, "id">,
-  ): Promise<ChannelEntity> {
-    try {
-      const persistenceChannel = this.toPersistence(channel);
-      const result = await this.client.channel.create({
-        data: { ...persistenceChannel },
-        include: {
-          message: false,
-          message_reaction: false,
-          user_channel: {
-            include: { user: true },
-          },
-        },
-      });
-      return ChannelEntity.fromPersistence(
-        result,
-        result.user_channel?.map((uc) => uc.user) || [],
-      );
-    } catch (error) {
-      this.logger.logToConsole(
-        LoggerContextStatus.ERROR,
-        LoggerContext.REPOSITORY,
-        LoggerContextEntity.CHANNEL,
-        `createMinimal | ${error.message}`,
       );
       return null;
     }

--- a/src/tests/channel/channelCommand.test.ts
+++ b/src/tests/channel/channelCommand.test.ts
@@ -1,0 +1,140 @@
+import { ChannelCommand } from "@application/command/channelCommand";
+import { IDiscordService } from "@domain/interfaces/services/IDiscordService";
+import { ILoggerService } from "@domain/interfaces/services/ILogger";
+import { ICreateChannel } from "@domain/interfaces/useCases/channel/ICreateChannel";
+import { IDeleteChannel } from "@domain/interfaces/useCases/channel/IDeleteChannel";
+import { IUpdateChannel } from "@domain/interfaces/useCases/channel/IUpdateChannel";
+import {
+  Client,
+  Events,
+  GuildChannel,
+  GuildMember,
+  Message,
+  PartialGuildMember,
+} from "discord.js";
+
+type DiscordServiceMockType = IDiscordService<
+  Message,
+  GuildMember,
+  PartialGuildMember,
+  Client
+>;
+
+describe("ChannelCommand", () => {
+  let channelCommand: ChannelCommand;
+
+  let createChannel: jest.Mocked<ICreateChannel>;
+  let updateChannel: jest.Mocked<IUpdateChannel>;
+  let deleteChannel: jest.Mocked<IDeleteChannel>;
+  let discordService: jest.Mocked<DiscordServiceMockType>;
+
+  beforeEach(() => {
+    discordService = <jest.Mocked<DiscordServiceMockType>>{
+      client: <Client>(<unknown>{
+        on: jest.fn(),
+      }),
+    };
+    createChannel = {
+      execute: jest.fn(),
+    } as jest.Mocked<ICreateChannel>;
+    updateChannel = {
+      execute: jest.fn(),
+    } as jest.Mocked<IUpdateChannel>;
+    deleteChannel = {
+      execute: jest.fn(),
+    } as jest.Mocked<IDeleteChannel>;
+    channelCommand = new ChannelCommand(
+      discordService,
+      {} as ILoggerService,
+      createChannel,
+      updateChannel,
+      deleteChannel,
+    );
+  });
+
+  it("should call createChannel.execute when a new channel created", async () => {
+    const channelMock = <GuildChannel>{
+      id: "1",
+      name: "my-channel",
+      url: "https://discord.com/channels/999999999999999999/999999999999999999",
+      createdAt: new Date(),
+    };
+
+    const eventCallbacks = new Map();
+    (discordService.client.on as jest.Mock).mockImplementation(
+      (event, callback) => {
+        eventCallbacks.set(event, callback);
+      },
+    );
+
+    await channelCommand.handleCreateChannel();
+
+    const channelCreateCallback = eventCallbacks.get(Events.ChannelCreate);
+    expect(channelCreateCallback).toBeDefined();
+
+    await channelCreateCallback(channelMock);
+
+    expect(createChannel.execute).toHaveBeenCalledWith(
+      ChannelCommand.toChannelCreateEntity(channelMock),
+    );
+  });
+
+  it("should call updateChannel.execute when send data to update channel", async () => {
+    const channelIdMock = {
+      id: "1234567890",
+    };
+    const oldChannelMock = <GuildChannel>{
+      ...channelIdMock,
+      name: "old-channel-name",
+      url: "https://discord.com/channels/999999999999999999/999999999999999999",
+      createdAt: new Date("2024-01-01"),
+    };
+
+    const newChannelMock = <GuildChannel>{
+      ...channelIdMock,
+      name: "new-channel-name",
+      url: "https://discord.com/channels/999999999999999999/999999999999999999",
+      createdAt: new Date(),
+    };
+
+    const eventCallbacks = new Map();
+    (discordService.client.on as jest.Mock).mockImplementation(
+      (event, callback) => {
+        eventCallbacks.set(event, callback);
+      },
+    );
+
+    await channelCommand.handleUpdateChannel();
+
+    const channelUpdateCallback = eventCallbacks.get(Events.ChannelUpdate);
+    expect(channelUpdateCallback).toBeDefined();
+
+    await channelUpdateCallback(oldChannelMock, newChannelMock);
+
+    expect(updateChannel.execute).toHaveBeenCalledWith(
+      channelIdMock.id,
+      ChannelCommand.toChannelCreateEntity(newChannelMock),
+    );
+  });
+
+  it("should call deleteChannel.execute when channel is deleted", async () => {
+    const channelMock = {
+      id: "12345",
+    } as GuildChannel;
+
+    let deleteCallback: (channel: GuildChannel) => Promise<void>;
+
+    (discordService.client.on as jest.Mock).mockImplementation(
+      (event, callback) => {
+        if (event === Events.ChannelDelete) {
+          deleteCallback = callback;
+        }
+      },
+    );
+
+    await channelCommand.handleDeleteChannel();
+    await deleteCallback!(channelMock);
+
+    expect(deleteChannel.execute).toHaveBeenCalledWith("12345");
+  });
+});

--- a/src/tests/channel/channelUseCases.test.ts
+++ b/src/tests/channel/channelUseCases.test.ts
@@ -1,0 +1,281 @@
+import { ILoggerService } from "@domain/interfaces/services/ILogger";
+import { ErrorMessages } from "@domain/types/ErrorMessages";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "@domain/types/LoggerContextEnum";
+import { CreateChannel } from "@domain/useCases/channel/CreateChannel";
+import { DeleteChannel } from "@domain/useCases/channel/DeleteChannel";
+import { UpdateChannel } from "@domain/useCases/channel/UpdateChannel";
+import { ChannelRepository } from "@infra/repositories/ChannelRepository";
+import { mockDeep, MockProxy } from "jest-mock-extended";
+
+const mockChannelId = {
+  id: 1,
+};
+
+const mockChannelValue = {
+  platformId: "1234567890",
+  name: "channel-name",
+  url: "https://discord.com/channels/999999999999999999/999999999999999999",
+  createdAt: new Date(),
+};
+
+const mockChannelCompleteData = {
+  ...mockChannelId,
+  platformId: "1234567890",
+  name: "channel-name",
+  url: "https://discord.com/channels/999999999999999999/999999999999999999",
+  createdAt: new Date(),
+  user: [],
+  message: [],
+  messageReaction: [],
+};
+
+describe("Channel useCases", () => {
+  let createChannelCase: CreateChannel;
+  let updateChannelCase: UpdateChannel;
+  let deleteChannelCase: DeleteChannel;
+
+  let channelRepository: MockProxy<ChannelRepository>;
+  let loggerMock: MockProxy<ILoggerService>;
+
+  beforeEach(() => {
+    loggerMock = mockDeep<ILoggerService>();
+    channelRepository = mockDeep<ChannelRepository>();
+    createChannelCase = new CreateChannel(channelRepository, loggerMock);
+    updateChannelCase = new UpdateChannel(channelRepository, loggerMock);
+    deleteChannelCase = new DeleteChannel(channelRepository, loggerMock);
+  });
+
+  describe("createChannel", () => {
+    it("should create a new channel", async () => {
+      const mockChannel = { ...mockChannelValue, ...mockChannelId };
+      const mockResponse = {
+        success: true,
+        data: mockChannel,
+        message: "Channel saved successfully",
+      };
+
+      channelRepository.create.mockResolvedValue(mockChannel);
+
+      const result = await createChannelCase.execute(mockChannelValue);
+
+      expect(result).toEqual(mockResponse);
+      expect(channelRepository.create).toHaveBeenCalledTimes(1);
+      expect(channelRepository.create).toHaveBeenCalledWith({
+        ...mockChannelValue,
+        id: undefined,
+      });
+    });
+
+    it("should handle error when failing to create a channel", async () => {
+      const errorMessage = "Something went wrong!";
+      channelRepository.create.mockRejectedValue(new Error(errorMessage));
+
+      const result = await createChannelCase.execute(mockChannelValue);
+
+      expect(result).toBeUndefined();
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.USER,
+        `executeCreateChannel | ${errorMessage}`,
+      );
+    });
+  });
+
+  describe("updateChannel", () => {
+    it("should update a channel", async () => {
+      const id = 1;
+      const channelChangedData = {
+        platformId: "1234567890",
+        name: "main-hall",
+        url: "https://discord.com/channels/999999999999999999/999999999999999999",
+        createdAt: new Date(),
+      };
+
+      const updatedChannel = {
+        ...mockChannelCompleteData,
+        name: "main-hall",
+      };
+
+      channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
+      channelRepository.updateById.mockResolvedValue(updatedChannel);
+
+      const result = await updateChannelCase.execute(id, channelChangedData);
+
+      expect(result).toEqual({
+        success: true,
+        data: updatedChannel,
+      });
+
+      expect(channelRepository.updateById).toHaveBeenCalledTimes(1);
+      expect(channelRepository.updateById).toHaveBeenCalledWith(
+        id,
+        channelChangedData,
+      );
+    });
+
+    it("should update a channel by platformId", async () => {
+      const platformId = "1234567890";
+      const id = 1;
+      const channelChangedData = {
+        platformId: "1234567890",
+        name: "main-hall",
+        url: "https://discord.com/channels/999999999999999999/999999999999999999",
+        createdAt: new Date(),
+      };
+
+      const updatedChannel = {
+        ...mockChannelCompleteData,
+        name: "main-hall",
+      };
+
+      channelRepository.findByPlatformId.mockResolvedValue(
+        mockChannelCompleteData,
+      );
+      channelRepository.updateById.mockResolvedValue(updatedChannel);
+
+      const result = await updateChannelCase.execute(
+        platformId,
+        channelChangedData,
+      );
+
+      expect(result).toEqual({
+        success: true,
+        data: updatedChannel,
+      });
+
+      expect(channelRepository.updateById).toHaveBeenCalledTimes(1);
+      expect(channelRepository.updateById).toHaveBeenCalledWith(
+        id,
+        channelChangedData,
+      );
+    });
+
+    it("should returns a not found response when channel not found", async () => {
+      const id = 1;
+      const channelChangedData = {
+        platformId: "1234567890",
+        name: "main-hall",
+        url: "https://discord.com/channels/999999999999999999/999999999999999999",
+        createdAt: new Date(),
+      };
+
+      const result = await updateChannelCase.execute(id, channelChangedData);
+
+      expect(result).toEqual({
+        success: false,
+        data: null,
+        message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
+      });
+      expect(channelRepository.findById).toHaveBeenCalledTimes(1);
+      expect(channelRepository.findById).toHaveBeenCalledWith(id);
+      expect(channelRepository.updateById).not.toHaveBeenCalledTimes(1);
+    });
+
+    it("should return error when failing to update a channel", async () => {
+      const id = 1;
+      const errorMessage = `Channel not found with id ${id}`;
+      const channelChangedData = {
+        platformId: "1234567890",
+        name: "main-hall",
+        url: "https://discord.com/channels/999999999999999999/999999999999999999",
+        createdAt: new Date(),
+      };
+      channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
+      channelRepository.updateById.mockRejectedValue(new Error(errorMessage));
+
+      const result = await updateChannelCase.execute(id, channelChangedData);
+
+      expect(result).toEqual({
+        success: false,
+        data: null,
+        message: errorMessage,
+      });
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.ERROR,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `UpdateChannel.execute | ${errorMessage}`,
+      );
+    });
+  });
+
+  describe("deleteChannel", () => {
+    it("should delete a channel", async () => {
+      const id = 1;
+      channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
+      channelRepository.deleteById.mockResolvedValue(true);
+
+      const result = await deleteChannelCase.execute(id);
+
+      expect(result).toEqual({
+        success: true,
+        data: true,
+      });
+
+      expect(channelRepository.deleteById).toHaveBeenCalledTimes(1);
+      expect(channelRepository.deleteById).toHaveBeenCalledWith(id);
+    });
+
+    it("should update a channel by platformId", async () => {
+      const platformId = "1234567890";
+
+      channelRepository.findByPlatformId.mockResolvedValue(
+        mockChannelCompleteData,
+      );
+      channelRepository.deleteById.mockResolvedValue(true);
+
+      const result = await deleteChannelCase.execute(platformId);
+
+      expect(result).toEqual({
+        success: true,
+        data: true,
+      });
+
+      expect(channelRepository.deleteById).toHaveBeenCalledTimes(1);
+      expect(channelRepository.deleteById).toHaveBeenCalledWith(
+        mockChannelCompleteData.id,
+      );
+    });
+
+    it("should returns a not found response when channel not found", async () => {
+      const id = 1;
+
+      const result = await deleteChannelCase.execute(id);
+
+      expect(result).toEqual({
+        success: false,
+        data: null,
+        message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
+      });
+      expect(channelRepository.findById).toHaveBeenCalledTimes(1);
+      expect(channelRepository.findById).toHaveBeenCalledWith(id);
+      expect(channelRepository.deleteById).not.toHaveBeenCalledTimes(1);
+    });
+
+    it("should return error when failing to delete a channel", async () => {
+      const id = 1;
+      const errorMessage = `Channel not found with id ${id}`;
+      channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
+      channelRepository.deleteById.mockRejectedValue(new Error(errorMessage));
+
+      const result = await deleteChannelCase.execute(id);
+
+      expect(result).toEqual({
+        success: false,
+        data: false,
+        message: errorMessage,
+      });
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.ERROR,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `DeleteChannel.execute | ${errorMessage}`,
+      );
+    });
+  });
+});

--- a/src/tests/channel/channelUseCases.test.ts
+++ b/src/tests/channel/channelUseCases.test.ts
@@ -1,5 +1,4 @@
 import { ILoggerService } from "@domain/interfaces/services/ILogger";
-import { ErrorMessages } from "@domain/types/ErrorMessages";
 import {
   LoggerContext,
   LoggerContextEntity,
@@ -52,17 +51,17 @@ describe("Channel useCases", () => {
   describe("createChannel", () => {
     it("should create a new channel", async () => {
       const mockChannel = { ...mockChannelValue, ...mockChannelId };
-      const mockResponse = {
-        success: true,
-        data: mockChannel,
-        message: "Channel saved successfully",
-      };
 
       channelRepository.create.mockResolvedValue(mockChannel);
 
-      const result = await createChannelCase.execute(mockChannelValue);
+      await createChannelCase.execute(mockChannelValue);
 
-      expect(result).toEqual(mockResponse);
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Channel ${mockChannel.id} - ${mockChannel.name} saved successfully`,
+      );
       expect(channelRepository.create).toHaveBeenCalledTimes(1);
       expect(channelRepository.create).toHaveBeenCalledWith({
         ...mockChannelValue,
@@ -79,8 +78,8 @@ describe("Channel useCases", () => {
       expect(result).toBeUndefined();
       expect(loggerMock.logToConsole).toHaveBeenCalledWith(
         LoggerContextStatus.ERROR,
-        LoggerContext.COMMAND,
-        LoggerContextEntity.USER,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
         `executeCreateChannel | ${errorMessage}`,
       );
     });
@@ -104,13 +103,14 @@ describe("Channel useCases", () => {
       channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
       channelRepository.updateById.mockResolvedValue(updatedChannel);
 
-      const result = await updateChannelCase.execute(id, channelChangedData);
+      await updateChannelCase.execute(id, channelChangedData);
 
-      expect(result).toEqual({
-        success: true,
-        data: updatedChannel,
-      });
-
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Channel ${updatedChannel.id} - ${updatedChannel.name} has been updated`,
+      );
       expect(channelRepository.updateById).toHaveBeenCalledTimes(1);
       expect(channelRepository.updateById).toHaveBeenCalledWith(
         id,
@@ -138,16 +138,14 @@ describe("Channel useCases", () => {
       );
       channelRepository.updateById.mockResolvedValue(updatedChannel);
 
-      const result = await updateChannelCase.execute(
-        platformId,
-        channelChangedData,
+      await updateChannelCase.execute(platformId, channelChangedData);
+
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Channel ${updatedChannel.id} - ${updatedChannel.name} has been updated`,
       );
-
-      expect(result).toEqual({
-        success: true,
-        data: updatedChannel,
-      });
-
       expect(channelRepository.updateById).toHaveBeenCalledTimes(1);
       expect(channelRepository.updateById).toHaveBeenCalledWith(
         id,
@@ -164,13 +162,8 @@ describe("Channel useCases", () => {
         createdAt: new Date(),
       };
 
-      const result = await updateChannelCase.execute(id, channelChangedData);
+      await updateChannelCase.execute(id, channelChangedData);
 
-      expect(result).toEqual({
-        success: false,
-        data: null,
-        message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
-      });
       expect(channelRepository.findById).toHaveBeenCalledTimes(1);
       expect(channelRepository.findById).toHaveBeenCalledWith(id);
       expect(channelRepository.updateById).not.toHaveBeenCalledTimes(1);
@@ -188,13 +181,8 @@ describe("Channel useCases", () => {
       channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
       channelRepository.updateById.mockRejectedValue(new Error(errorMessage));
 
-      const result = await updateChannelCase.execute(id, channelChangedData);
+      await updateChannelCase.execute(id, channelChangedData);
 
-      expect(result).toEqual({
-        success: false,
-        data: null,
-        message: errorMessage,
-      });
       expect(loggerMock.logToConsole).toHaveBeenCalledWith(
         LoggerContextStatus.ERROR,
         LoggerContext.USECASE,
@@ -210,13 +198,14 @@ describe("Channel useCases", () => {
       channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
       channelRepository.deleteById.mockResolvedValue(true);
 
-      const result = await deleteChannelCase.execute(id);
+      await deleteChannelCase.execute(id);
 
-      expect(result).toEqual({
-        success: true,
-        data: true,
-      });
-
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Was channel ${mockChannelCompleteData.id} - ${mockChannelCompleteData.name} deleted: ${true}`,
+      );
       expect(channelRepository.deleteById).toHaveBeenCalledTimes(1);
       expect(channelRepository.deleteById).toHaveBeenCalledWith(id);
     });
@@ -229,13 +218,14 @@ describe("Channel useCases", () => {
       );
       channelRepository.deleteById.mockResolvedValue(true);
 
-      const result = await deleteChannelCase.execute(platformId);
+      await deleteChannelCase.execute(platformId);
 
-      expect(result).toEqual({
-        success: true,
-        data: true,
-      });
-
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Was channel ${mockChannelCompleteData.id} - ${mockChannelCompleteData.name} deleted: ${true}`,
+      );
       expect(channelRepository.deleteById).toHaveBeenCalledTimes(1);
       expect(channelRepository.deleteById).toHaveBeenCalledWith(
         mockChannelCompleteData.id,
@@ -245,13 +235,8 @@ describe("Channel useCases", () => {
     it("should returns a not found response when channel not found", async () => {
       const id = 1;
 
-      const result = await deleteChannelCase.execute(id);
+      await deleteChannelCase.execute(id);
 
-      expect(result).toEqual({
-        success: false,
-        data: null,
-        message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
-      });
       expect(channelRepository.findById).toHaveBeenCalledTimes(1);
       expect(channelRepository.findById).toHaveBeenCalledWith(id);
       expect(channelRepository.deleteById).not.toHaveBeenCalledTimes(1);
@@ -263,13 +248,8 @@ describe("Channel useCases", () => {
       channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
       channelRepository.deleteById.mockRejectedValue(new Error(errorMessage));
 
-      const result = await deleteChannelCase.execute(id);
+      await deleteChannelCase.execute(id);
 
-      expect(result).toEqual({
-        success: false,
-        data: false,
-        message: errorMessage,
-      });
       expect(loggerMock.logToConsole).toHaveBeenCalledWith(
         LoggerContextStatus.ERROR,
         LoggerContext.USECASE,


### PR DESCRIPTION
## 📖 Descrição

Implementado handlers para persistência dos canais do discord

## 🔗 Link da tarefa

[CPDD-241](https://www.notion.so/cpdd/useCases-Canais-Registrar-evento-do-discord-de-cria-o-de-canal-1f2c5f6d25f88053975ccd3c512ed9c0?source=copy_link)

## ✏️ Tipo de mudança

- [ ] Bugfix
- [x] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

## 🤔 Como foi testado?

<!-- Descreva os passos para reproduzir os testes e as verificações feitas. -->

## ☑️ Checklist

- [ ] Código segue o padrão de estilo do projeto
- [ ] Testes unitários foram adicionados
- [ ] A documentação foi atualizada (se aplicável)
