### PR TITLE
Atualização com homol

### DIFF
--- a/src/application/command/channelCommand.ts
+++ b/src/application/command/channelCommand.ts
@@ -111,7 +111,7 @@ export class ChannelCommand implements IChannelCommand {
     await this.deleteChannel.execute(channel.id);
   }
 
-  private static toChannelCreateEntity(
+  public static toChannelCreateEntity(
     discordChannel: GuildChannel,
   ): CreateChannelType {
     return {

--- a/src/application/command/channelCommand.ts
+++ b/src/application/command/channelCommand.ts
@@ -1,0 +1,158 @@
+import { IChannelCommand } from "@domain/interfaces/commands/IChannelCommand";
+import { IDiscordService } from "@domain/interfaces/services/IDiscordService";
+import { ILoggerService } from "@domain/interfaces/services/ILogger";
+import {
+  CreateChannelType,
+  ICreateChannel,
+} from "@domain/interfaces/useCases/channel/ICreateChannel";
+import { IDeleteChannel } from "@domain/interfaces/useCases/channel/IDeleteChannel";
+import { IUpdateChannel } from "@domain/interfaces/useCases/channel/IUpdateChannel";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "@domain/types/LoggerContextEnum";
+import {
+  Client,
+  Events,
+  GuildChannel,
+  GuildMember,
+  Message,
+  PartialGuildMember,
+  PermissionsBitField,
+} from "discord.js";
+
+export class ChannelCommand implements IChannelCommand {
+  constructor(
+    private readonly discordService: IDiscordService<
+      Message,
+      GuildMember,
+      PartialGuildMember,
+      Client
+    >,
+    private readonly logger: ILoggerService,
+    private readonly createChannel: ICreateChannel,
+    private readonly updateChannel: IUpdateChannel,
+    private readonly deleteChannel: IDeleteChannel,
+  ) {
+    this.handleCreateChannel();
+    this.handleUpdateChannel();
+    this.handleDeleteChannel();
+  }
+
+  private get discordClient(): Client {
+    return this.discordService.client;
+  }
+
+  public async handleCreateChannel(): Promise<void> {
+    try {
+      this.discordClient.on(
+        Events.ChannelCreate,
+        this.onChannelCreated.bind(this),
+      );
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.CHANNEL,
+        `Fail to create channel, \ncause:\n ${error.message}`,
+      );
+    }
+  }
+
+  public async handleUpdateChannel(): Promise<void> {
+    try {
+      this.discordClient.on(
+        Events.ChannelUpdate,
+        this.onChannelUpdated.bind(this),
+      );
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.CHANNEL,
+        `Fail to update channel, \ncause:\n ${error.message}`,
+      );
+    }
+  }
+
+  public async handleDeleteChannel(): Promise<void> {
+    try {
+      this.discordClient.on(
+        Events.ChannelDelete,
+        this.onChannelDeleted.bind(this),
+      );
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.CHANNEL,
+        `Fail to delete channel, \ncause:\n ${error.message}`,
+      );
+    }
+  }
+
+  private async onChannelCreated(channel: GuildChannel): Promise<void> {
+    this.checkIfBotHasChannelPermissions(channel);
+    await this.createChannel.execute(
+      ChannelCommand.toChannelCreateEntity(channel),
+    );
+  }
+
+  private async onChannelUpdated(channel: GuildChannel): Promise<void> {
+    this.checkIfBotHasChannelPermissions(channel);
+    await this.updateChannel.execute(
+      channel.id,
+      ChannelCommand.toChannelCreateEntity(channel),
+    );
+  }
+
+  private async onChannelDeleted(channel: GuildChannel): Promise<void> {
+    this.checkIfBotHasChannelPermissions(channel);
+    await this.deleteChannel.execute(channel.id);
+  }
+
+  private checkIfBotHasChannelPermissions(channel: GuildChannel): void {
+    if (!channel.guild) {
+      console.log("❌ Canal não pertence a uma guild");
+      return;
+    }
+
+    const botMember = channel.guild.members.cache.get(
+      this.discordClient.user.id,
+    );
+    if (!botMember) {
+      console.log("❌ Bot member não encontrado na guild do canal");
+      return;
+    }
+
+    const requiredPermissions = [
+      PermissionsBitField.Flags.ViewChannel,
+      PermissionsBitField.Flags.SendMessages,
+      PermissionsBitField.Flags.ManageChannels,
+    ];
+
+    const hasPermissions = requiredPermissions.every((permission) =>
+      channel.permissionsFor(botMember).has(permission),
+    );
+
+    if (!hasPermissions) {
+      console.log("❌ Bot falta permissões no canal:");
+      requiredPermissions.forEach((permission) => {
+        const hasPerm = channel.permissionsFor(botMember).has(permission);
+        console.log(`   ${hasPerm ? "✅" : "❌"} ${permission}`);
+      });
+    }
+  }
+
+  private static toChannelCreateEntity(
+    discordChannel: GuildChannel,
+  ): CreateChannelType {
+    return {
+      platformId: discordChannel.id,
+      name: discordChannel.name,
+      url: discordChannel.url,
+      createdAt: discordChannel.createdAt,
+    };
+  }
+}

--- a/src/application/command/channelCommand.ts
+++ b/src/application/command/channelCommand.ts
@@ -14,7 +14,6 @@ import {
 } from "@domain/types/LoggerContextEnum";
 import {
   Client,
-  Events,
   GuildChannel,
   GuildMember,
   Message,
@@ -45,10 +44,7 @@ export class ChannelCommand implements IChannelCommand {
 
   public async handleCreateChannel(): Promise<void> {
     try {
-      this.discordClient.on(
-        Events.ChannelCreate,
-        this.onChannelCreated.bind(this),
-      );
+      this.discordService.onCreateChannel(this.onChannelCreated.bind(this));
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
@@ -61,10 +57,7 @@ export class ChannelCommand implements IChannelCommand {
 
   public async handleUpdateChannel(): Promise<void> {
     try {
-      this.discordClient.on(
-        Events.ChannelUpdate,
-        this.onChannelUpdated.bind(this),
-      );
+      this.discordService.onChangeChannel(this.onChannelUpdated.bind(this));
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
@@ -77,10 +70,7 @@ export class ChannelCommand implements IChannelCommand {
 
   public async handleDeleteChannel(): Promise<void> {
     try {
-      this.discordClient.on(
-        Events.ChannelDelete,
-        this.onChannelDeleted.bind(this),
-      );
+      this.discordService.onDeleteChannel(this.onChannelDeleted.bind(this));
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,

--- a/src/application/command/channelCommand.ts
+++ b/src/application/command/channelCommand.ts
@@ -38,10 +38,6 @@ export class ChannelCommand implements IChannelCommand {
     this.handleDeleteChannel();
   }
 
-  private get discordClient(): Client {
-    return this.discordService.client;
-  }
-
   public async handleCreateChannel(): Promise<void> {
     try {
       this.discordService.onCreateChannel(this.onChannelCreated.bind(this));

--- a/src/application/command/channelCommand.ts
+++ b/src/application/command/channelCommand.ts
@@ -19,7 +19,6 @@ import {
   GuildMember,
   Message,
   PartialGuildMember,
-  PermissionsBitField,
 } from "discord.js";
 
 export class ChannelCommand implements IChannelCommand {
@@ -93,56 +92,23 @@ export class ChannelCommand implements IChannelCommand {
   }
 
   private async onChannelCreated(channel: GuildChannel): Promise<void> {
-    this.checkIfBotHasChannelPermissions(channel);
     await this.createChannel.execute(
       ChannelCommand.toChannelCreateEntity(channel),
     );
   }
 
-  private async onChannelUpdated(channel: GuildChannel): Promise<void> {
-    this.checkIfBotHasChannelPermissions(channel);
+  private async onChannelUpdated(
+    _oldChannel: GuildChannel,
+    newChannel: GuildChannel,
+  ): Promise<void> {
     await this.updateChannel.execute(
-      channel.id,
-      ChannelCommand.toChannelCreateEntity(channel),
+      newChannel.id,
+      ChannelCommand.toChannelCreateEntity(newChannel),
     );
   }
 
   private async onChannelDeleted(channel: GuildChannel): Promise<void> {
-    this.checkIfBotHasChannelPermissions(channel);
     await this.deleteChannel.execute(channel.id);
-  }
-
-  private checkIfBotHasChannelPermissions(channel: GuildChannel): void {
-    if (!channel.guild) {
-      console.log("❌ Canal não pertence a uma guild");
-      return;
-    }
-
-    const botMember = channel.guild.members.cache.get(
-      this.discordClient.user.id,
-    );
-    if (!botMember) {
-      console.log("❌ Bot member não encontrado na guild do canal");
-      return;
-    }
-
-    const requiredPermissions = [
-      PermissionsBitField.Flags.ViewChannel,
-      PermissionsBitField.Flags.SendMessages,
-      PermissionsBitField.Flags.ManageChannels,
-    ];
-
-    const hasPermissions = requiredPermissions.every((permission) =>
-      channel.permissionsFor(botMember).has(permission),
-    );
-
-    if (!hasPermissions) {
-      console.log("❌ Bot falta permissões no canal:");
-      requiredPermissions.forEach((permission) => {
-        const hasPerm = channel.permissionsFor(botMember).has(permission);
-        console.log(`   ${hasPerm ? "✅" : "❌"} ${permission}`);
-      });
-    }
   }
 
   private static toChannelCreateEntity(

--- a/src/application/command/messageCommand.ts
+++ b/src/application/command/messageCommand.ts
@@ -1,0 +1,101 @@
+import { Client, Message } from "discord.js";
+import { IDiscordService } from "@services/IDiscordService";
+import { ILoggerService } from "@services/ILogger";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "@type/LoggerContextEnum";
+import { IRegisterMessage } from "@interfaces/useCases/message/IRegisterMessage";
+import { RegisterMessageInput } from "@interfaces/useCases/message/IRegisterMessage";
+
+export class MessageCommand {
+  constructor(
+    private readonly discordService: IDiscordService<
+      Message,
+      unknown,
+      unknown,
+      Client
+    >,
+    private readonly logger: ILoggerService,
+    private readonly registerMessage: IRegisterMessage,
+  ) {
+    this.executeMessage();
+  }
+
+  async executeMessage(): Promise<void> {
+    try {
+      this.discordService.onMessage(async (message) => {
+        if (message.author.bot) {
+          return;
+        }
+
+        if (!message.guild) {
+          return;
+        }
+
+        const input = MessageCommand.toRegisterMessageInput(message);
+        const result = await this.registerMessage.execute(input);
+
+        if (result.success) {
+          this.logger.logToConsole(
+            LoggerContextStatus.SUCCESS,
+            LoggerContext.COMMAND,
+            LoggerContextEntity.MESSAGE,
+            `Message registered successfully: ${message.id}`,
+          );
+        } else {
+          this.logger.logToConsole(
+            LoggerContextStatus.ERROR,
+            LoggerContext.COMMAND,
+            LoggerContextEntity.MESSAGE,
+            `Failed to register message: ${result.message || "Unknown error"}`,
+          );
+        }
+      });
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.MESSAGE,
+        `executeMessage | ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  static toRegisterMessageInput(message: Message): RegisterMessageInput {
+    let channelName = "Unknown Channel";
+    let channelUrl = "";
+
+    if (message.channel && "name" in message.channel && message.channel.name) {
+      channelName = message.channel.name;
+    }
+
+    if (message.channel && "url" in message.channel && message.channel.url) {
+      channelUrl = message.channel.url;
+    } else if (message.guild && message.channel && "id" in message.channel) {
+      channelUrl = `https://discord.com/channels/${message.guild.id}/${message.channel.id}`;
+    }
+
+    let userJoinedAt: Date | null = null;
+    if (message.member && message.member.joinedAt) {
+      userJoinedAt = message.member.joinedAt;
+    }
+
+    return {
+      platformId: message.id,
+      platformCreatedAt: new Date(message.createdTimestamp),
+      channelId: message.channel.id,
+      userId: message.author.id,
+      channelName: channelName,
+      channelUrl: channelUrl,
+      username: message.author.username,
+      userGlobalName: message.author.globalName,
+      userBot: message.author.bot,
+      userPlatformCreatedAt: message.author.createdTimestamp
+        ? new Date(message.author.createdTimestamp)
+        : undefined,
+      userJoinedAt: userJoinedAt,
+    };
+  }
+}

--- a/src/application/command/voiceEventCommand.ts
+++ b/src/application/command/voiceEventCommand.ts
@@ -2,6 +2,7 @@
 
 import {
   Client,
+  GuildChannel,
   GuildScheduledEvent,
   PartialGuildScheduledEvent,
 } from "discord.js";
@@ -25,6 +26,7 @@ export class VoiceEventCommand {
       unknown,
       unknown,
       Client,
+      GuildChannel,
       GuildScheduledEvent | PartialGuildScheduledEvent
     >,
     private readonly logger: ILoggerService,

--- a/src/contexts/app.context.ts
+++ b/src/contexts/app.context.ts
@@ -2,8 +2,10 @@ import { initializeDatabase } from "./database.context";
 import { initializeUserUseCases } from "./useUserCases.context";
 import { initializeDiscord } from "./discord.context";
 import { initializeVoiceEventUseCases } from "./useVoiceEventCases.context";
+import { initializeMessageUseCases } from "./useMessageCases.context";
 import { UserCommand } from "@application/command/userCommand";
 import { VoiceEventCommand } from "@application/command/voiceEventCommand";
+import { MessageCommand } from "@application/command/messageCommand";
 import { Logger } from "@application/services/Logger";
 import {
   LoggerContextStatus,
@@ -15,7 +17,12 @@ import { ErrorMessages } from "@type/ErrorMessages";
 export function initializeApp() {
   // Aqui vao as dependencias externas
   const logger = new Logger();
-  const { userRepository, audioEventRepository } = initializeDatabase(logger);
+  const {
+    userRepository,
+    audioEventRepository,
+    messageRepository,
+    channelRepository,
+  } = initializeDatabase(logger);
   const { discordService } = initializeDiscord();
   const { TOKEN_BOT } = process.env;
 
@@ -32,6 +39,13 @@ export function initializeApp() {
   const userUseCases = initializeUserUseCases(userRepository, logger);
   const { registerVoiceEvent, finalizeVoiceEvent } =
     initializeVoiceEventUseCases(audioEventRepository, logger);
+  const { registerMessage } = initializeMessageUseCases(
+    messageRepository,
+    userRepository,
+    channelRepository,
+    userUseCases.createUserCase,
+    logger,
+  );
 
   // E finalmente as inicializacoes da aplicacao
   new UserCommand(
@@ -47,6 +61,8 @@ export function initializeApp() {
     registerVoiceEvent,
     finalizeVoiceEvent,
   );
+
+  new MessageCommand(discordService, logger, registerMessage);
 
   // Isso deve ser executado depois que o user command for iniciado
   discordService.registerEvents();

--- a/src/contexts/app.context.ts
+++ b/src/contexts/app.context.ts
@@ -1,19 +1,21 @@
-import { initializeDatabase } from "./database.context";
-import { initializeUserUseCases } from "./useUserCases.context";
-import { initializeDiscord } from "./discord.context";
+import { ChannelCommand } from "@application/command/channelCommand";
 import { UserCommand } from "@application/command/userCommand";
 import { Logger } from "@application/services/Logger";
+import { ErrorMessages } from "@type/ErrorMessages";
 import {
-  LoggerContextStatus,
   LoggerContext,
   LoggerContextEntity,
+  LoggerContextStatus,
 } from "@type/LoggerContextEnum";
-import { ErrorMessages } from "@type/ErrorMessages";
+import { initializeDatabase } from "./database.context";
+import { initializeDiscord } from "./discord.context";
+import { initializeChannelUseCases } from "./useChannelCases.context";
+import { initializeUserUseCases } from "./useUserCases.context";
 
 export function initializeApp() {
   // Aqui vao as dependencias externas
   const logger = new Logger();
-  const { userRepository } = initializeDatabase(logger);
+  const { userRepository, channelRepository } = initializeDatabase(logger);
   const { discordService } = initializeDiscord();
   const { TOKEN_BOT } = process.env;
 
@@ -39,4 +41,13 @@ export function initializeApp() {
   // Isso deve ser executado depois que o user command for iniciado
   discordService.registerEvents();
   discordService.client.login(TOKEN_BOT);
+
+  const channelUseCases = initializeChannelUseCases(channelRepository, logger);
+  new ChannelCommand(
+    discordService,
+    logger,
+    channelUseCases.createChannelCase,
+    channelUseCases.updateChannelCase,
+    channelUseCases.deleteChannelCase,
+  );
 }

--- a/src/contexts/useChannelCases.context.ts
+++ b/src/contexts/useChannelCases.context.ts
@@ -1,0 +1,19 @@
+import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepository";
+import { CreateChannel } from "@domain/useCases/channel/CreateChannel";
+import { DeleteChannel } from "@domain/useCases/channel/DeleteChannel";
+import { UpdateChannel } from "@domain/useCases/channel/UpdateChannel";
+import { ILoggerService } from "@services/ILogger";
+
+export const initializeChannelUseCases = (
+  channelRepository: IChannelRepository,
+  logger: ILoggerService,
+) => {
+  const createChannelCase = new CreateChannel(channelRepository, logger);
+  const updateChannelCase = new UpdateChannel(channelRepository, logger);
+  const deleteChannelCase = new DeleteChannel(channelRepository, logger);
+  return {
+    createChannelCase,
+    updateChannelCase,
+    deleteChannelCase,
+  };
+};

--- a/src/contexts/useMessageCases.context.ts
+++ b/src/contexts/useMessageCases.context.ts
@@ -1,0 +1,26 @@
+import { IMessageRepository } from "@repositories/IMessageRepository";
+import { IUserRepository } from "@repositories/IUserRepository";
+import { IChannelRepository } from "@repositories/IChannelRepository";
+import { ICreateUser } from "@interfaces/useCases/user/ICreateUser";
+import { ILoggerService } from "@services/ILogger";
+import { RegisterMessage } from "@domain/useCases/message/RegisterMessage";
+
+export function initializeMessageUseCases(
+  messageRepository: IMessageRepository,
+  userRepository: IUserRepository,
+  channelRepository: IChannelRepository,
+  createUser: ICreateUser,
+  logger: ILoggerService,
+): {
+  registerMessage: RegisterMessage;
+} {
+  const registerMessage = new RegisterMessage(
+    messageRepository,
+    userRepository,
+    channelRepository,
+    createUser,
+    logger,
+  );
+
+  return { registerMessage };
+}

--- a/src/domain/interfaces/commands/IChannelCommand.ts
+++ b/src/domain/interfaces/commands/IChannelCommand.ts
@@ -1,0 +1,5 @@
+export interface IChannelCommand {
+  handleCreateChannel(): Promise<void>;
+  handleUpdateChannel(): Promise<void>;
+  handleDeleteChannel(): Promise<void>;
+}

--- a/src/domain/interfaces/repositories/IChannelRepository.ts
+++ b/src/domain/interfaces/repositories/IChannelRepository.ts
@@ -1,7 +1,6 @@
 import { ChannelEntity } from "../../entities/Channel";
 
 export interface IChannelRepository {
-  createMinimal(channel: Omit<ChannelEntity, "id">): Promise<ChannelEntity>;
   create(voiceChannel: Omit<ChannelEntity, "id">): Promise<ChannelEntity>;
   createMany(voiceChannels: Omit<ChannelEntity, "id">[]): Promise<number>;
   findById(

--- a/src/domain/interfaces/repositories/IChannelRepository.ts
+++ b/src/domain/interfaces/repositories/IChannelRepository.ts
@@ -1,6 +1,7 @@
 import { ChannelEntity } from "../../entities/Channel";
 
 export interface IChannelRepository {
+  createMinimal(channel: Omit<ChannelEntity, "id">): Promise<ChannelEntity>;
   create(voiceChannel: Omit<ChannelEntity, "id">): Promise<ChannelEntity>;
   createMany(voiceChannels: Omit<ChannelEntity, "id">[]): Promise<number>;
   findById(

--- a/src/domain/interfaces/services/IDiscordService.ts
+++ b/src/domain/interfaces/services/IDiscordService.ts
@@ -2,7 +2,8 @@ export interface IDiscordService<
   M = unknown,
   U = unknown,
   P = unknown,
-  T = unknown
+  T = unknown,
+  C = unknown,
 > {
   client: T;
   onDiscordStart(handler: () => void): void;
@@ -10,4 +11,7 @@ export interface IDiscordService<
   onNewUser(handler: (member: U) => void): void;
   onUserLeave(handler: (member: U | P) => void): void;
   registerEvents(): void;
+  onCreateChannel(handler: (channel: C) => void): void;
+  onChangeChannel(handler: (oldChannel: C, newChannel: C) => void): void;
+  onDeleteChannel(handler: (channel: C) => void): void;
 }

--- a/src/domain/interfaces/useCases/channel/IChannelId.ts
+++ b/src/domain/interfaces/useCases/channel/IChannelId.ts
@@ -1,0 +1,1 @@
+export type ChannelIdType = number | string;

--- a/src/domain/interfaces/useCases/channel/ICreateChannel.ts
+++ b/src/domain/interfaces/useCases/channel/ICreateChannel.ts
@@ -1,0 +1,8 @@
+import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
+import { ChannelEntity } from "@domain/entities/Channel";
+
+export type CreateChannelType = Omit<ChannelEntity, "id">;
+
+export interface ICreateChannel {
+  execute(channel: CreateChannelType): Promise<GenericOutputDto<ChannelEntity>>;
+}

--- a/src/domain/interfaces/useCases/channel/ICreateChannel.ts
+++ b/src/domain/interfaces/useCases/channel/ICreateChannel.ts
@@ -1,8 +1,7 @@
-import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
 import { ChannelEntity } from "@domain/entities/Channel";
 
 export type CreateChannelType = Omit<ChannelEntity, "id">;
 
 export interface ICreateChannel {
-  execute(channel: CreateChannelType): Promise<GenericOutputDto<ChannelEntity>>;
+  execute(channel: CreateChannelType): Promise<void>;
 }

--- a/src/domain/interfaces/useCases/channel/IDeleteChannel.ts
+++ b/src/domain/interfaces/useCases/channel/IDeleteChannel.ts
@@ -1,0 +1,6 @@
+import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
+import { ChannelIdType } from "./IChannelId";
+
+export interface IDeleteChannel {
+  execute(id: ChannelIdType): Promise<GenericOutputDto<boolean>>;
+}

--- a/src/domain/interfaces/useCases/channel/IDeleteChannel.ts
+++ b/src/domain/interfaces/useCases/channel/IDeleteChannel.ts
@@ -1,6 +1,5 @@
-import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
 import { ChannelIdType } from "./IChannelId";
 
 export interface IDeleteChannel {
-  execute(id: ChannelIdType): Promise<GenericOutputDto<boolean>>;
+  execute(id: ChannelIdType): Promise<void>;
 }

--- a/src/domain/interfaces/useCases/channel/IUpdateChannel.ts
+++ b/src/domain/interfaces/useCases/channel/IUpdateChannel.ts
@@ -1,0 +1,10 @@
+import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
+import { ChannelEntity } from "@domain/entities/Channel";
+import { ChannelIdType } from "./IChannelId";
+
+export interface IUpdateChannel {
+  execute(
+    id: ChannelIdType,
+    data: Partial<ChannelEntity>,
+  ): Promise<GenericOutputDto<ChannelEntity>>;
+}

--- a/src/domain/interfaces/useCases/channel/IUpdateChannel.ts
+++ b/src/domain/interfaces/useCases/channel/IUpdateChannel.ts
@@ -1,10 +1,6 @@
-import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
 import { ChannelEntity } from "@domain/entities/Channel";
 import { ChannelIdType } from "./IChannelId";
 
 export interface IUpdateChannel {
-  execute(
-    id: ChannelIdType,
-    data: Partial<ChannelEntity>,
-  ): Promise<GenericOutputDto<ChannelEntity>>;
+  execute(id: ChannelIdType, data: Partial<ChannelEntity>): Promise<void>;
 }

--- a/src/domain/interfaces/useCases/message/IRegisterMessage.ts
+++ b/src/domain/interfaces/useCases/message/IRegisterMessage.ts
@@ -1,0 +1,22 @@
+import { MessageEntity } from "@entities/Message";
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+
+export interface RegisterMessageInput {
+  platformId: string;
+  platformCreatedAt: Date;
+  channelId: string;
+  userId: string;
+  channelName?: string;
+  channelUrl?: string;
+  username?: string;
+  userGlobalName?: string | null;
+  userBot?: boolean;
+  userPlatformCreatedAt?: Date;
+  userJoinedAt?: Date | null;
+}
+
+export interface IRegisterMessage {
+  execute(
+    input: RegisterMessageInput,
+  ): Promise<GenericOutputDto<MessageEntity>>;
+}

--- a/src/domain/types/ErrorMessages.ts
+++ b/src/domain/types/ErrorMessages.ts
@@ -4,4 +4,5 @@ export enum ErrorMessages {
   USER_ALREADY_EXISTS = "User already exists",
   UNKNOWN_ERROR = "Unknown error occurred",
   MISSING_SECRET = "Secret key not found",
+  CHANNEL_NOT_FOUND = "Channel not found with id",
 }

--- a/src/domain/useCases/channel/CreateChannel.ts
+++ b/src/domain/useCases/channel/CreateChannel.ts
@@ -1,0 +1,41 @@
+import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
+import { ChannelEntity } from "@domain/entities/Channel";
+import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepository";
+import { ILoggerService } from "@domain/interfaces/services/ILogger";
+import {
+  CreateChannelType,
+  ICreateChannel,
+} from "@domain/interfaces/useCases/channel/ICreateChannel";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "@domain/types/LoggerContextEnum";
+
+export class CreateChannel implements ICreateChannel {
+  constructor(
+    private readonly channelRepository: IChannelRepository,
+    private readonly logger: ILoggerService,
+  ) {}
+
+  public async execute(
+    channel: CreateChannelType,
+  ): Promise<GenericOutputDto<ChannelEntity>> {
+    try {
+      const createdChannel =
+        await this.channelRepository.createMinimal(channel);
+      return {
+        data: { ...createdChannel },
+        success: true,
+        message: "Channel saved successfully",
+      };
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.USER,
+        `executeCreateChannel | ${error.message}`,
+      );
+    }
+  }
+}

--- a/src/domain/useCases/channel/CreateChannel.ts
+++ b/src/domain/useCases/channel/CreateChannel.ts
@@ -22,8 +22,7 @@ export class CreateChannel implements ICreateChannel {
     channel: CreateChannelType,
   ): Promise<GenericOutputDto<ChannelEntity>> {
     try {
-      const createdChannel =
-        await this.channelRepository.createMinimal(channel);
+      const createdChannel = await this.channelRepository.create(channel);
       return {
         data: { ...createdChannel },
         success: true,

--- a/src/domain/useCases/channel/CreateChannel.ts
+++ b/src/domain/useCases/channel/CreateChannel.ts
@@ -1,5 +1,3 @@
-import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
-import { ChannelEntity } from "@domain/entities/Channel";
 import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepository";
 import { ILoggerService } from "@domain/interfaces/services/ILogger";
 import {
@@ -18,21 +16,20 @@ export class CreateChannel implements ICreateChannel {
     private readonly logger: ILoggerService,
   ) {}
 
-  public async execute(
-    channel: CreateChannelType,
-  ): Promise<GenericOutputDto<ChannelEntity>> {
+  public async execute(channel: CreateChannelType): Promise<void> {
     try {
       const createdChannel = await this.channelRepository.create(channel);
-      return {
-        data: { ...createdChannel },
-        success: true,
-        message: "Channel saved successfully",
-      };
+      this.logger.logToConsole(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Channel ${createdChannel.id} - ${createdChannel.name} saved successfully`,
+      );
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
-        LoggerContext.COMMAND,
-        LoggerContextEntity.USER,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
         `executeCreateChannel | ${error.message}`,
       );
     }

--- a/src/domain/useCases/channel/DeleteChannel.ts
+++ b/src/domain/useCases/channel/DeleteChannel.ts
@@ -1,0 +1,53 @@
+import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
+import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepository";
+import { ILoggerService } from "@domain/interfaces/services/ILogger";
+import { ChannelIdType } from "@domain/interfaces/useCases/channel/IChannelId";
+import { IDeleteChannel } from "@domain/interfaces/useCases/channel/IDeleteChannel";
+import { ErrorMessages } from "@domain/types/ErrorMessages";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "@domain/types/LoggerContextEnum";
+
+export class DeleteChannel implements IDeleteChannel {
+  constructor(
+    private readonly channelRepository: IChannelRepository,
+    private readonly logger: ILoggerService,
+  ) {}
+
+  public async execute(id: ChannelIdType): Promise<GenericOutputDto<boolean>> {
+    try {
+      const channel =
+        typeof id === "string"
+          ? await this.channelRepository.findByPlatformId(id)
+          : await this.channelRepository.findById(id);
+
+      if (!channel) {
+        return {
+          data: null,
+          success: false,
+          message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
+        };
+      }
+
+      const isDeleted = await this.channelRepository.deleteById(channel.id);
+      return {
+        data: isDeleted,
+        success: true,
+      };
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.USECASE,
+        LoggerContextEntity.USER,
+        `DeleteChannel.execute | ${error.message}`,
+      );
+      return {
+        data: false,
+        success: false,
+        message: error.message,
+      };
+    }
+  }
+}

--- a/src/domain/useCases/channel/DeleteChannel.ts
+++ b/src/domain/useCases/channel/DeleteChannel.ts
@@ -40,7 +40,7 @@ export class DeleteChannel implements IDeleteChannel {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
         LoggerContext.USECASE,
-        LoggerContextEntity.USER,
+        LoggerContextEntity.CHANNEL,
         `DeleteChannel.execute | ${error.message}`,
       );
       return {

--- a/src/domain/useCases/channel/DeleteChannel.ts
+++ b/src/domain/useCases/channel/DeleteChannel.ts
@@ -1,4 +1,3 @@
-import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
 import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepository";
 import { ILoggerService } from "@domain/interfaces/services/ILogger";
 import { ChannelIdType } from "@domain/interfaces/useCases/channel/IChannelId";
@@ -16,7 +15,7 @@ export class DeleteChannel implements IDeleteChannel {
     private readonly logger: ILoggerService,
   ) {}
 
-  public async execute(id: ChannelIdType): Promise<GenericOutputDto<boolean>> {
+  public async execute(id: ChannelIdType): Promise<void> {
     try {
       const channel =
         typeof id === "string"
@@ -24,18 +23,21 @@ export class DeleteChannel implements IDeleteChannel {
           : await this.channelRepository.findById(id);
 
       if (!channel) {
-        return {
-          data: null,
-          success: false,
-          message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
-        };
+        this.logger.logToConsole(
+          LoggerContextStatus.ERROR,
+          LoggerContext.USECASE,
+          LoggerContextEntity.CHANNEL,
+          `DeleteChannel.execute | ${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
+        );
       }
 
       const isDeleted = await this.channelRepository.deleteById(channel.id);
-      return {
-        data: isDeleted,
-        success: true,
-      };
+      this.logger.logToConsole(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Was channel ${channel.id} - ${channel.name} deleted: ${isDeleted}`,
+      );
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
@@ -43,11 +45,6 @@ export class DeleteChannel implements IDeleteChannel {
         LoggerContextEntity.CHANNEL,
         `DeleteChannel.execute | ${error.message}`,
       );
-      return {
-        data: false,
-        success: false,
-        message: error.message,
-      };
     }
   }
 }

--- a/src/domain/useCases/channel/UpdateChannel.ts
+++ b/src/domain/useCases/channel/UpdateChannel.ts
@@ -48,7 +48,7 @@ export class UpdateChannel implements IUpdateChannel {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
         LoggerContext.USECASE,
-        LoggerContextEntity.USER,
+        LoggerContextEntity.CHANNEL,
         `UpdateChannel.execute | ${error.message}`,
       );
       return {

--- a/src/domain/useCases/channel/UpdateChannel.ts
+++ b/src/domain/useCases/channel/UpdateChannel.ts
@@ -1,0 +1,60 @@
+import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
+import { ChannelEntity } from "@domain/entities/Channel";
+import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepository";
+import { ILoggerService } from "@domain/interfaces/services/ILogger";
+import { ChannelIdType } from "@domain/interfaces/useCases/channel/IChannelId";
+import { IUpdateChannel } from "@domain/interfaces/useCases/channel/IUpdateChannel";
+import { ErrorMessages } from "@domain/types/ErrorMessages";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "@domain/types/LoggerContextEnum";
+
+export class UpdateChannel implements IUpdateChannel {
+  constructor(
+    private readonly channelRepository: IChannelRepository,
+    private readonly logger: ILoggerService,
+  ) {}
+
+  public async execute(
+    id: ChannelIdType,
+    data: Partial<ChannelEntity>,
+  ): Promise<GenericOutputDto<ChannelEntity>> {
+    try {
+      const channel =
+        typeof id === "string"
+          ? await this.channelRepository.findByPlatformId(id)
+          : await this.channelRepository.findById(id);
+
+      if (!channel) {
+        return {
+          data: null,
+          success: false,
+          message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
+        };
+      }
+
+      const updatedChannel = await this.channelRepository.updateById(
+        channel.id,
+        data,
+      );
+      return {
+        data: { ...updatedChannel },
+        success: true,
+      };
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.USECASE,
+        LoggerContextEntity.USER,
+        `UpdateChannel.execute | ${error.message}`,
+      );
+      return {
+        data: null,
+        success: false,
+        message: error.message,
+      };
+    }
+  }
+}

--- a/src/domain/useCases/channel/UpdateChannel.ts
+++ b/src/domain/useCases/channel/UpdateChannel.ts
@@ -1,4 +1,3 @@
-import { GenericOutputDto } from "@domain/dtos/GenericOutputDto";
 import { ChannelEntity } from "@domain/entities/Channel";
 import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepository";
 import { ILoggerService } from "@domain/interfaces/services/ILogger";
@@ -20,7 +19,7 @@ export class UpdateChannel implements IUpdateChannel {
   public async execute(
     id: ChannelIdType,
     data: Partial<ChannelEntity>,
-  ): Promise<GenericOutputDto<ChannelEntity>> {
+  ): Promise<void> {
     try {
       const channel =
         typeof id === "string"
@@ -28,11 +27,12 @@ export class UpdateChannel implements IUpdateChannel {
           : await this.channelRepository.findById(id);
 
       if (!channel) {
-        return {
-          data: null,
-          success: false,
-          message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
-        };
+        this.logger.logToConsole(
+          LoggerContextStatus.ERROR,
+          LoggerContext.USECASE,
+          LoggerContextEntity.CHANNEL,
+          `UpdateChannel.execute | ${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
+        );
       }
 
       const updatedChannel = await this.channelRepository.updateById(
@@ -40,10 +40,12 @@ export class UpdateChannel implements IUpdateChannel {
         data,
       );
 
-      return {
-        data: { ...updatedChannel },
-        success: true,
-      };
+      this.logger.logToConsole(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Channel ${updatedChannel.id} - ${updatedChannel.name} has been updated`,
+      );
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
@@ -51,11 +53,6 @@ export class UpdateChannel implements IUpdateChannel {
         LoggerContextEntity.CHANNEL,
         `UpdateChannel.execute | ${error.message}`,
       );
-      return {
-        data: null,
-        success: false,
-        message: error.message,
-      };
     }
   }
 }

--- a/src/domain/useCases/channel/UpdateChannel.ts
+++ b/src/domain/useCases/channel/UpdateChannel.ts
@@ -39,6 +39,7 @@ export class UpdateChannel implements IUpdateChannel {
         channel.id,
         data,
       );
+
       return {
         data: { ...updatedChannel },
         success: true,

--- a/src/domain/useCases/message/RegisterMessage.ts
+++ b/src/domain/useCases/message/RegisterMessage.ts
@@ -1,0 +1,150 @@
+import { MessageEntity } from "@entities/Message";
+import { IMessageRepository } from "@repositories/IMessageRepository";
+import { IUserRepository } from "@repositories/IUserRepository";
+import { IChannelRepository } from "@repositories/IChannelRepository";
+import { ICreateUser } from "@interfaces/useCases/user/ICreateUser";
+import { ILoggerService } from "@services/ILogger";
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+import { ErrorMessages } from "@type/ErrorMessages";
+import {
+  LoggerContextStatus,
+  LoggerContext,
+  LoggerContextEntity,
+} from "@type/LoggerContextEnum";
+import {
+  RegisterMessageInput,
+  IRegisterMessage,
+} from "@interfaces/useCases/message/IRegisterMessage";
+import { ChannelEntity } from "@entities/Channel";
+import { UserStatus } from "@type/UserStatusEnum";
+
+export class RegisterMessage implements IRegisterMessage {
+  constructor(
+    private readonly messageRepository: IMessageRepository,
+    private readonly userRepository: IUserRepository,
+    private readonly channelRepository: IChannelRepository,
+    private readonly createUser: ICreateUser,
+    private readonly logger: ILoggerService,
+  ) {}
+
+  async execute(
+    input: RegisterMessageInput,
+  ): Promise<GenericOutputDto<MessageEntity>> {
+    try {
+      let user = await this.userRepository.findByPlatformId(input.userId, true);
+
+      if (!user) {
+        if (!input.username) {
+          return {
+            data: null,
+            success: false,
+            message: "User data required for user creation",
+          };
+        }
+
+        const createUserInput = {
+          platformId: input.userId,
+          username: input.username,
+          globalName: input.userGlobalName || null,
+          bot: input.userBot || false,
+          status: UserStatus.ACTIVE,
+          platformCreatedAt: input.userPlatformCreatedAt,
+          joinedAt: input.userJoinedAt || null,
+          lastActive: undefined,
+        };
+
+        const createUserResult = await this.createUser.execute(createUserInput);
+        if (!createUserResult.success || !createUserResult.data) {
+          return {
+            data: null,
+            success: false,
+            message: createUserResult.message || ErrorMessages.UNKNOWN_ERROR,
+          };
+        }
+        user = createUserResult.data;
+      }
+
+      let channel = await this.channelRepository.findByPlatformId(
+        input.channelId,
+      );
+
+      if (!channel) {
+        const channelName = input.channelName || "Unknown Channel";
+        const channelUrl = input.channelUrl || "";
+
+        const channelData: Omit<ChannelEntity, "id"> = {
+          platformId: input.channelId,
+          name: channelName,
+          url: channelUrl,
+          createdAt: new Date(),
+        };
+
+        const newChannel = await this.channelRepository.create(channelData);
+        if (!newChannel) {
+          return {
+            data: null,
+            success: false,
+            message: "Failed to create channel",
+          };
+        }
+        channel = newChannel;
+      }
+
+      const existingMessage = await this.messageRepository
+        .findByPlatformId(input.platformId)
+        .catch(() => null);
+
+      if (existingMessage) {
+        return {
+          data: existingMessage,
+          success: false,
+          message: "Message already exists",
+        };
+      }
+
+      const messageData: Omit<MessageEntity, "id"> = {
+        platformId: input.platformId,
+        platformCreatedAt: input.platformCreatedAt,
+        isDeleted: false,
+        channel: channel,
+        user: user,
+        messageReactions: [],
+      };
+
+      const newMessage = await this.messageRepository.create(messageData);
+
+      if (!newMessage) {
+        return {
+          data: null,
+          success: false,
+          message: ErrorMessages.UNKNOWN_ERROR,
+        };
+      }
+
+      this.logger.logToConsole(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.MESSAGE,
+        `Message registered successfully: ${input.platformId}`,
+      );
+
+      return {
+        data: newMessage,
+        success: true,
+      };
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.USECASE,
+        LoggerContextEntity.MESSAGE,
+        `registerMessage.execute | ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return {
+        data: null,
+        success: false,
+        message:
+          error instanceof Error ? error.message : ErrorMessages.UNKNOWN_ERROR,
+      };
+    }
+  }
+}

--- a/src/infrastructure/persistence/prisma/models/dbml/schema.dbml
+++ b/src/infrastructure/persistence/prisma/models/dbml/schema.dbml
@@ -18,9 +18,9 @@ Table user {
   audio_event audio_event [not null]
   message message [not null]
   message_reaction message_reaction [not null]
-  user_channel user_channel [not null]
+  channels channel [not null]
   user_event user_event [not null]
-  user_role user_role [not null]
+  roles role [not null]
 }
 
 Table role {
@@ -29,18 +29,7 @@ Table role {
   created_at DateTime [default: `now()`, not null]
   platform_created_at DateTime [not null]
   platform_id String [unique, not null]
-  user_role user_role [not null]
-}
-
-Table user_role {
-  user_id String [not null]
-  roleId String [not null]
-  role role [not null]
-  user user [not null]
-
-  indexes {
-    (user_id, roleId) [pk]
-  }
+  users user [not null]
 }
 
 Table audio_event {
@@ -103,7 +92,7 @@ Table channel {
   audio_event audio_event [not null]
   message message [not null]
   message_reaction message_reaction [not null]
-  user_channel user_channel [not null]
+  users user [not null]
 }
 
 Table message_reaction {
@@ -119,21 +108,6 @@ Table message_reaction {
     (user_id, message_id) [unique]
   }
 }
-
-Table user_channel {
-  user_id String [not null]
-  channel_id String [not null]
-  channel channel [not null]
-  user user [not null]
-
-  indexes {
-    (user_id, channel_id) [pk]
-  }
-}
-
-Ref: user_role.roleId > role.platform_id
-
-Ref: user_role.user_id > user.platform_id
 
 Ref: audio_event.channel_id > channel.platform_id
 
@@ -154,7 +128,3 @@ Ref: message_reaction.channel_id > channel.platform_id
 Ref: message_reaction.message_id > message.platform_id
 
 Ref: message_reaction.user_id > user.platform_id
-
-Ref: user_channel.channel_id > channel.platform_id
-
-Ref: user_channel.user_id > user.platform_id

--- a/src/infrastructure/persistence/prisma/models/dbml/schema.dbml
+++ b/src/infrastructure/persistence/prisma/models/dbml/schema.dbml
@@ -109,6 +109,16 @@ Table message_reaction {
   }
 }
 
+Table UserChannel {
+  channelsId Int [ref: > channel.id]
+  usersId Int [ref: > user.id]
+}
+
+Table UserRole {
+  rolesId Int [ref: > role.id]
+  usersId Int [ref: > user.id]
+}
+
 Ref: audio_event.channel_id > channel.platform_id
 
 Ref: audio_event.creator_id > user.platform_id

--- a/src/infrastructure/persistence/prisma/models/dbml/schema.dbml
+++ b/src/infrastructure/persistence/prisma/models/dbml/schema.dbml
@@ -118,6 +118,11 @@ Table UserRole {
   usersId Int [ref: > user.id]
 }
 
+Enum EventType {
+  JOINED
+  LEFT
+}
+
 Ref: audio_event.channel_id > channel.platform_id
 
 Ref: audio_event.creator_id > user.platform_id

--- a/src/infrastructure/persistence/prisma/models/migrations/20251110221108_altera_modelagem_explicita_implicita/migration.sql
+++ b/src/infrastructure/persistence/prisma/models/migrations/20251110221108_altera_modelagem_explicita_implicita/migration.sql
@@ -1,0 +1,54 @@
+/*
+  Warnings:
+
+  - You are about to drop the `user_channel` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `user_role` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE `user_channel` DROP FOREIGN KEY `user_channel_channel_id_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `user_channel` DROP FOREIGN KEY `user_channel_user_id_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `user_role` DROP FOREIGN KEY `user_role_roleId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `user_role` DROP FOREIGN KEY `user_role_user_id_fkey`;
+
+-- DropTable
+DROP TABLE `user_channel`;
+
+-- DropTable
+DROP TABLE `user_role`;
+
+-- CreateTable
+CREATE TABLE `_UserRole` (
+    `A` INTEGER NOT NULL,
+    `B` INTEGER NOT NULL,
+
+    UNIQUE INDEX `_UserRole_AB_unique`(`A`, `B`),
+    INDEX `_UserRole_B_index`(`B`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `_UserChannel` (
+    `A` INTEGER NOT NULL,
+    `B` INTEGER NOT NULL,
+
+    UNIQUE INDEX `_UserChannel_AB_unique`(`A`, `B`),
+    INDEX `_UserChannel_B_index`(`B`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `_UserRole` ADD CONSTRAINT `_UserRole_A_fkey` FOREIGN KEY (`A`) REFERENCES `role`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `_UserRole` ADD CONSTRAINT `_UserRole_B_fkey` FOREIGN KEY (`B`) REFERENCES `user`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `_UserChannel` ADD CONSTRAINT `_UserChannel_A_fkey` FOREIGN KEY (`A`) REFERENCES `channel`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `_UserChannel` ADD CONSTRAINT `_UserChannel_B_fkey` FOREIGN KEY (`B`) REFERENCES `user`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/infrastructure/persistence/prisma/models/schema.prisma
+++ b/src/infrastructure/persistence/prisma/models/schema.prisma
@@ -29,7 +29,7 @@ model User {
   message             Message[]
   message_reaction    MessageReaction[]
   channels            Channel[]         @relation("UserChannel")
-  user_event          userEvent[]
+  user_event          UserEvent[]
   roles               Role[]            @relation("UserRole")
 
   @@map("user")

--- a/src/infrastructure/persistence/prisma/models/schema.prisma
+++ b/src/infrastructure/persistence/prisma/models/schema.prisma
@@ -28,33 +28,22 @@ model User {
   audio_event         AudioEvent[]
   message             Message[]
   message_reaction    MessageReaction[]
-  user_channel        UserChannel[]
+  channels            Channel[]         @relation("UserChannel")
   user_event          userEvent[]
-  user_role           UserRole[]
+  roles               Role[]            @relation("UserRole")
 
   @@map("user")
 }
 
 model Role {
-  id                  Int        @id @default(autoincrement())
+  id                  Int      @id @default(autoincrement())
   name                String
-  created_at          DateTime   @default(now())
+  created_at          DateTime @default(now())
   platform_created_at DateTime
-  platform_id         String     @unique
-  user_role           UserRole[]
+  platform_id         String   @unique
+  users               User[]   @relation("UserRole")
 
   @@map("role")
-}
-
-model UserRole {
-  user_id String
-  roleId  String
-  role    Role   @relation(fields: [roleId], references: [platform_id])
-  user    User   @relation(fields: [user_id], references: [platform_id])
-
-  @@id([user_id, roleId])
-  @@index([roleId], map: "user_role_roleId_fkey")
-  @@map("user_role")
 }
 
 model AudioEvent {
@@ -128,7 +117,7 @@ model Channel {
   audio_event      AudioEvent[]
   message          Message[]
   message_reaction MessageReaction[]
-  user_channel     UserChannel[]
+  users            User[]            @relation("UserChannel")
 
   @@map("channel")
 }
@@ -146,15 +135,4 @@ model MessageReaction {
   @@index([channel_id], map: "message_reaction_channel_id_fkey")
   @@index([message_id], map: "message_reaction_message_id_fkey")
   @@map("message_reaction")
-}
-
-model UserChannel {
-  user_id    String
-  channel_id String
-  channel    Channel @relation(fields: [channel_id], references: [platform_id])
-  user       User    @relation(fields: [user_id], references: [platform_id])
-
-  @@id([user_id, channel_id])
-  @@index([channel_id], map: "user_channel_channel_id_fkey")
-  @@map("user_channel")
 }

--- a/src/infrastructure/persistence/repositories/ChannelRepository.ts
+++ b/src/infrastructure/persistence/repositories/ChannelRepository.ts
@@ -22,10 +22,10 @@ export class ChannelRepository implements IChannelRepository {
   }
 
   /**
-   * Cria um novo usuario no banco de dados.
+   * Cria um novo canal no banco de dados.
    *
-   * @param {Omit<ChannelEntity, "id">} channel Os dados do usuario a ser criado.
-   * @returns {Promise<ChannelEntity>} O usuario criado.
+   * @param {Omit<ChannelEntity, "id">} channel Os dados do canal a ser criado.
+   * @returns {Promise<ChannelEntity>} O canal criado.
    */
   async create(channel: Omit<ChannelEntity, "id">): Promise<ChannelEntity> {
     try {
@@ -33,12 +33,12 @@ export class ChannelRepository implements IChannelRepository {
         data: {
           ...this.toPersistence(channel),
           message: {
-            connect: channel.message.map((message) => ({
+            connect: channel?.message.map((message) => ({
               platform_id: message.platformId,
             })),
           },
           message_reaction: {
-            connect: channel.messageReaction.map((messageReaction) => ({
+            connect: channel?.messageReaction.map((messageReaction) => ({
               id: messageReaction.id,
             })),
           },
@@ -71,6 +71,36 @@ export class ChannelRepository implements IChannelRepository {
         LoggerContext.REPOSITORY,
         LoggerContextEntity.CHANNEL,
         `create | ${error.message}`,
+      );
+      return null;
+    }
+  }
+
+  public async createMinimal(
+    channel: Omit<ChannelEntity, "id">,
+  ): Promise<ChannelEntity> {
+    try {
+      const persistenceChannel = this.toPersistence(channel);
+      const result = await this.client.channel.create({
+        data: { ...persistenceChannel },
+        include: {
+          message: false,
+          message_reaction: false,
+          user_channel: {
+            include: { user: true },
+          },
+        },
+      });
+      return ChannelEntity.fromPersistence(
+        result,
+        result.user_channel?.map((uc) => uc.user) || [],
+      );
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.CHANNEL,
+        `createMinimal | ${error.message}`,
       );
       return null;
     }
@@ -134,10 +164,10 @@ export class ChannelRepository implements IChannelRepository {
   }
 
   /**
-   * Retorna um usuario pelo id.
+   * Retorna um canal pelo id.
    *
-   * @param {number} id O id do usuario a ser buscado.
-   * @returns {Promise<ChannelEntity | null>} O usuario encontrado. Se o usuario nao existir, retorna null.
+   * @param {number} id O id do canal a ser buscado.
+   * @returns {Promise<ChannelEntity | null>} O canal encontrado. Se o canal nao existir, retorna null.
    */
   async findById(id: number): Promise<ChannelEntity | null> {
     try {
@@ -174,10 +204,10 @@ export class ChannelRepository implements IChannelRepository {
   }
 
   /**
-   * Retorna um usuario pelo id do Discord.
+   * Retorna um canal pelo id do Discord.
    *
-   * @param {string} id O id do Discord do usuario a ser buscado.
-   * @returns {Promise<ChannelEntity | null>} O usuario encontrado. Se o usuario nao existir, retorna null.
+   * @param {string} id O id do Discord do canal a ser buscado.
+   * @returns {Promise<ChannelEntity | null>} O canal encontrado. Se o canal nao existir, retorna null.
    */
   async findByPlatformId(id: string): Promise<ChannelEntity | null> {
     try {
@@ -212,10 +242,10 @@ export class ChannelRepository implements IChannelRepository {
   }
 
   /**
-   * Retorna uma lista de usuarios.
+   * Retorna uma lista de canais.
    *
-   * @param {number} [limit] O limite de usuarios a serem retornados.
-   * @returns {Promise<ChannelEntity[]>} A lista de usuarios.
+   * @param {number} [limit] O limite de canais a serem retornados.
+   * @returns {Promise<ChannelEntity[]>} A lista de canais.
    */
   async listAll(limit?: number): Promise<ChannelEntity[]> {
     try {
@@ -249,11 +279,11 @@ export class ChannelRepository implements IChannelRepository {
   }
 
   /**
-   * Atualiza um usuario pelo id.
+   * Atualiza um canal pelo id.
    *
-   * @param {number} id O id do usuario a ser atualizado.
-   * @param {ChannelEntity} channel Os dados do usuario a ser atualizado.
-   * @returns {Promise<ChannelEntity | null>} O usuario atualizado. Se o usuario nao existir, retorna null.
+   * @param {number} id O id do canal a ser atualizado.
+   * @param {ChannelEntity} channel Os dados do canal a ser atualizado.
+   * @returns {Promise<ChannelEntity | null>} O canal atualizado. Se o canal nao existir, retorna null.
    */
   async updateById(
     id: number,
@@ -276,10 +306,10 @@ export class ChannelRepository implements IChannelRepository {
   }
 
   /**
-   * Deleta um usuario pelo id.
+   * Deleta um canal pelo id.
    *
-   * @param {number} id O id do usuario a ser deletado.
-   * @returns {Promise<boolean>} True se o usuario foi deletado, false caso contrario.
+   * @param {number} id O id do canal a ser deletado.
+   * @returns {Promise<boolean>} True se o canal foi deletado, false caso contrario.
    */
   async deleteById(id: number): Promise<boolean> {
     try {

--- a/src/infrastructure/persistence/repositories/ChannelRepository.ts
+++ b/src/infrastructure/persistence/repositories/ChannelRepository.ts
@@ -33,12 +33,12 @@ export class ChannelRepository implements IChannelRepository {
         data: {
           ...this.toPersistence(channel),
           message: {
-            connect: channel?.message.map((message) => ({
+            connect: channel?.message?.map((message) => ({
               platform_id: message.platformId,
             })),
           },
           message_reaction: {
-            connect: channel?.messageReaction.map((messageReaction) => ({
+            connect: channel?.messageReaction?.map((messageReaction) => ({
               id: messageReaction.id,
             })),
           },
@@ -71,36 +71,6 @@ export class ChannelRepository implements IChannelRepository {
         LoggerContext.REPOSITORY,
         LoggerContextEntity.CHANNEL,
         `create | ${error.message}`,
-      );
-      return null;
-    }
-  }
-
-  public async createMinimal(
-    channel: Omit<ChannelEntity, "id">,
-  ): Promise<ChannelEntity> {
-    try {
-      const persistenceChannel = this.toPersistence(channel);
-      const result = await this.client.channel.create({
-        data: { ...persistenceChannel },
-        include: {
-          message: false,
-          message_reaction: false,
-          user_channel: {
-            include: { user: true },
-          },
-        },
-      });
-      return ChannelEntity.fromPersistence(
-        result,
-        result.user_channel?.map((uc) => uc.user) || [],
-      );
-    } catch (error) {
-      this.logger.logToConsole(
-        LoggerContextStatus.ERROR,
-        LoggerContext.REPOSITORY,
-        LoggerContextEntity.CHANNEL,
-        `createMinimal | ${error.message}`,
       );
       return null;
     }

--- a/src/infrastructure/persistence/repositories/RoleRepository.ts
+++ b/src/infrastructure/persistence/repositories/RoleRepository.ts
@@ -25,13 +25,10 @@ export class RoleRepository implements IRoleRepository {
     try {
       const result = await this.client.role.findUnique({
         where: { id },
-        include: { user_role: { include: { user: true } } },
+        include: { users: true },
       });
 
-      return RoleEntity.fromPersistence(
-        result,
-        result.user_role.map((userRole) => userRole.user),
-      );
+      return RoleEntity.fromPersistence(result, result.users);
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
@@ -44,15 +41,10 @@ export class RoleRepository implements IRoleRepository {
   async findByUserPlatformId(id: string): Promise<RoleEntity[] | null> {
     try {
       const result = await this.client.role.findMany({
-        where: { user_role: { some: { user: { platform_id: id } } } },
-        include: { user_role: { include: { user: true } } },
+        where: { users: { some: { platform_id: id } } },
+        include: { users: true },
       });
-      return result.map((role) =>
-        RoleEntity.fromPersistence(
-          role,
-          role.user_role.map((userRole) => userRole.user),
-        ),
-      );
+      return result.map((role) => RoleEntity.fromPersistence(role, role.users));
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
@@ -66,12 +58,9 @@ export class RoleRepository implements IRoleRepository {
     try {
       const result = await this.client.role.findUnique({
         where: { platform_id: id },
-        include: { user_role: { include: { user: true } } },
+        include: { users: true },
       });
-      return RoleEntity.fromPersistence(
-        result,
-        result.user_role.map((userRole) => userRole.user),
-      );
+      return RoleEntity.fromPersistence(result, result.users);
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
@@ -85,13 +74,10 @@ export class RoleRepository implements IRoleRepository {
     try {
       const results = await this.client.role.findMany({
         take: limit,
-        include: { user_role: { include: { user: true } } },
+        include: { users: true },
       });
       return results.map((result) =>
-        RoleEntity.fromPersistence(
-          result,
-          result.user_role.map((userRole) => userRole.user),
-        ),
+        RoleEntity.fromPersistence(result, result.users),
       );
     } catch (error) {
       this.logger.logToConsole(

--- a/src/infrastructure/persistence/repositories/UserRepository.ts
+++ b/src/infrastructure/persistence/repositories/UserRepository.ts
@@ -84,8 +84,8 @@ export class UserRepository implements IUserRepository {
         include: {
           message: true,
           message_reaction: true,
-          user_channel: { include: { channel: true } },
-          user_role: { include: { role: true } },
+          channels: true,
+          roles: true,
           audio_event: true,
         },
       });
@@ -95,8 +95,8 @@ export class UserRepository implements IUserRepository {
             result,
             result.message,
             result.message_reaction,
-            result.user_channel.map((userChannel) => userChannel.channel),
-            result.user_role.map((userRole) => userRole.role),
+            result.channels,
+            result.roles,
             result.audio_event,
           )
         : null;
@@ -133,8 +133,8 @@ export class UserRepository implements IUserRepository {
         include: {
           message: true,
           message_reaction: true,
-          user_channel: { include: { channel: true } },
-          user_role: { include: { role: true } },
+          channels: true,
+          roles: true,
           audio_event: true,
         },
       });
@@ -144,8 +144,8 @@ export class UserRepository implements IUserRepository {
             result,
             result.message,
             result.message_reaction,
-            result.user_channel.map((userChannel) => userChannel.channel),
-            result.user_role.map((userRole) => userRole.role),
+            result.channels,
+            result.roles,
             result.audio_event,
           )
         : null;
@@ -182,8 +182,8 @@ export class UserRepository implements IUserRepository {
         include: {
           message: true,
           message_reaction: true,
-          user_channel: { include: { channel: true } },
-          user_role: { include: { role: true } },
+          channels: true,
+          roles: true,
           audio_event: true,
         },
       });
@@ -193,8 +193,8 @@ export class UserRepository implements IUserRepository {
           result,
           result.message,
           result.message_reaction,
-          result.user_channel.map((userChannel) => userChannel.channel),
-          result.user_role.map((userRole) => userRole.role),
+          result.channels,
+          result.roles,
           result.audio_event,
         ),
       );

--- a/src/tests/channel/channelCommand.test.ts
+++ b/src/tests/channel/channelCommand.test.ts
@@ -1,0 +1,140 @@
+import { ChannelCommand } from "@application/command/channelCommand";
+import { IDiscordService } from "@domain/interfaces/services/IDiscordService";
+import { ILoggerService } from "@domain/interfaces/services/ILogger";
+import { ICreateChannel } from "@domain/interfaces/useCases/channel/ICreateChannel";
+import { IDeleteChannel } from "@domain/interfaces/useCases/channel/IDeleteChannel";
+import { IUpdateChannel } from "@domain/interfaces/useCases/channel/IUpdateChannel";
+import {
+  Client,
+  Events,
+  GuildChannel,
+  GuildMember,
+  Message,
+  PartialGuildMember,
+} from "discord.js";
+
+type DiscordServiceMockType = IDiscordService<
+  Message,
+  GuildMember,
+  PartialGuildMember,
+  Client
+>;
+
+describe("ChannelCommand", () => {
+  let channelCommand: ChannelCommand;
+
+  let createChannel: jest.Mocked<ICreateChannel>;
+  let updateChannel: jest.Mocked<IUpdateChannel>;
+  let deleteChannel: jest.Mocked<IDeleteChannel>;
+  let discordService: jest.Mocked<DiscordServiceMockType>;
+
+  beforeEach(() => {
+    discordService = <jest.Mocked<DiscordServiceMockType>>{
+      client: <Client>(<unknown>{
+        on: jest.fn(),
+      }),
+    };
+    createChannel = {
+      execute: jest.fn(),
+    } as jest.Mocked<ICreateChannel>;
+    updateChannel = {
+      execute: jest.fn(),
+    } as jest.Mocked<IUpdateChannel>;
+    deleteChannel = {
+      execute: jest.fn(),
+    } as jest.Mocked<IDeleteChannel>;
+    channelCommand = new ChannelCommand(
+      discordService,
+      {} as ILoggerService,
+      createChannel,
+      updateChannel,
+      deleteChannel,
+    );
+  });
+
+  it("should call createChannel.execute when a new channel created", async () => {
+    const channelMock = <GuildChannel>{
+      id: "1",
+      name: "my-channel",
+      url: "https://discord.com/channels/999999999999999999/999999999999999999",
+      createdAt: new Date(),
+    };
+
+    const eventCallbacks = new Map();
+    (discordService.client.on as jest.Mock).mockImplementation(
+      (event, callback) => {
+        eventCallbacks.set(event, callback);
+      },
+    );
+
+    await channelCommand.handleCreateChannel();
+
+    const channelCreateCallback = eventCallbacks.get(Events.ChannelCreate);
+    expect(channelCreateCallback).toBeDefined();
+
+    await channelCreateCallback(channelMock);
+
+    expect(createChannel.execute).toHaveBeenCalledWith(
+      ChannelCommand.toChannelCreateEntity(channelMock),
+    );
+  });
+
+  it("should call updateChannel.execute when send data to update channel", async () => {
+    const channelIdMock = {
+      id: "1234567890",
+    };
+    const oldChannelMock = <GuildChannel>{
+      ...channelIdMock,
+      name: "old-channel-name",
+      url: "https://discord.com/channels/999999999999999999/999999999999999999",
+      createdAt: new Date("2024-01-01"),
+    };
+
+    const newChannelMock = <GuildChannel>{
+      ...channelIdMock,
+      name: "new-channel-name",
+      url: "https://discord.com/channels/999999999999999999/999999999999999999",
+      createdAt: new Date(),
+    };
+
+    const eventCallbacks = new Map();
+    (discordService.client.on as jest.Mock).mockImplementation(
+      (event, callback) => {
+        eventCallbacks.set(event, callback);
+      },
+    );
+
+    await channelCommand.handleUpdateChannel();
+
+    const channelUpdateCallback = eventCallbacks.get(Events.ChannelUpdate);
+    expect(channelUpdateCallback).toBeDefined();
+
+    await channelUpdateCallback(oldChannelMock, newChannelMock);
+
+    expect(updateChannel.execute).toHaveBeenCalledWith(
+      channelIdMock.id,
+      ChannelCommand.toChannelCreateEntity(newChannelMock),
+    );
+  });
+
+  it("should call deleteChannel.execute when channel is deleted", async () => {
+    const channelMock = {
+      id: "12345",
+    } as GuildChannel;
+
+    let deleteCallback: (channel: GuildChannel) => Promise<void>;
+
+    (discordService.client.on as jest.Mock).mockImplementation(
+      (event, callback) => {
+        if (event === Events.ChannelDelete) {
+          deleteCallback = callback;
+        }
+      },
+    );
+
+    await channelCommand.handleDeleteChannel();
+    await deleteCallback!(channelMock);
+
+    expect(deleteChannel.execute).toHaveBeenCalledWith("12345");
+  });
+});

--- a/src/tests/channel/channelUseCases.test.ts
+++ b/src/tests/channel/channelUseCases.test.ts
@@ -1,0 +1,281 @@
+import { ILoggerService } from "@domain/interfaces/services/ILogger";
+import { ErrorMessages } from "@domain/types/ErrorMessages";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "@domain/types/LoggerContextEnum";
+import { CreateChannel } from "@domain/useCases/channel/CreateChannel";
+import { DeleteChannel } from "@domain/useCases/channel/DeleteChannel";
+import { UpdateChannel } from "@domain/useCases/channel/UpdateChannel";
+import { ChannelRepository } from "@infra/repositories/ChannelRepository";
+import { mockDeep, MockProxy } from "jest-mock-extended";
+
+const mockChannelId = {
+  id: 1,
+};
+
+const mockChannelValue = {
+  platformId: "1234567890",
+  name: "channel-name",
+  url: "https://discord.com/channels/999999999999999999/999999999999999999",
+  createdAt: new Date(),
+};
+
+const mockChannelCompleteData = {
+  ...mockChannelId,
+  platformId: "1234567890",
+  name: "channel-name",
+  url: "https://discord.com/channels/999999999999999999/999999999999999999",
+  createdAt: new Date(),
+  user: [],
+  message: [],
+  messageReaction: [],
+};
+
+describe("Channel useCases", () => {
+  let createChannelCase: CreateChannel;
+  let updateChannelCase: UpdateChannel;
+  let deleteChannelCase: DeleteChannel;
+
+  let channelRepository: MockProxy<ChannelRepository>;
+  let loggerMock: MockProxy<ILoggerService>;
+
+  beforeEach(() => {
+    loggerMock = mockDeep<ILoggerService>();
+    channelRepository = mockDeep<ChannelRepository>();
+    createChannelCase = new CreateChannel(channelRepository, loggerMock);
+    updateChannelCase = new UpdateChannel(channelRepository, loggerMock);
+    deleteChannelCase = new DeleteChannel(channelRepository, loggerMock);
+  });
+
+  describe("createChannel", () => {
+    it("should create a new channel", async () => {
+      const mockChannel = { ...mockChannelValue, ...mockChannelId };
+      const mockResponse = {
+        success: true,
+        data: mockChannel,
+        message: "Channel saved successfully",
+      };
+
+      channelRepository.create.mockResolvedValue(mockChannel);
+
+      const result = await createChannelCase.execute(mockChannelValue);
+
+      expect(result).toEqual(mockResponse);
+      expect(channelRepository.create).toHaveBeenCalledTimes(1);
+      expect(channelRepository.create).toHaveBeenCalledWith({
+        ...mockChannelValue,
+        id: undefined,
+      });
+    });
+
+    it("should handle error when failing to create a channel", async () => {
+      const errorMessage = "Something went wrong!";
+      channelRepository.create.mockRejectedValue(new Error(errorMessage));
+
+      const result = await createChannelCase.execute(mockChannelValue);
+
+      expect(result).toBeUndefined();
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.USER,
+        `executeCreateChannel | ${errorMessage}`,
+      );
+    });
+  });
+
+  describe("updateChannel", () => {
+    it("should update a channel", async () => {
+      const id = 1;
+      const channelChangedData = {
+        platformId: "1234567890",
+        name: "main-hall",
+        url: "https://discord.com/channels/999999999999999999/999999999999999999",
+        createdAt: new Date(),
+      };
+
+      const updatedChannel = {
+        ...mockChannelCompleteData,
+        name: "main-hall",
+      };
+
+      channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
+      channelRepository.updateById.mockResolvedValue(updatedChannel);
+
+      const result = await updateChannelCase.execute(id, channelChangedData);
+
+      expect(result).toEqual({
+        success: true,
+        data: updatedChannel,
+      });
+
+      expect(channelRepository.updateById).toHaveBeenCalledTimes(1);
+      expect(channelRepository.updateById).toHaveBeenCalledWith(
+        id,
+        channelChangedData,
+      );
+    });
+
+    it("should update a channel by platformId", async () => {
+      const platformId = "1234567890";
+      const id = 1;
+      const channelChangedData = {
+        platformId: "1234567890",
+        name: "main-hall",
+        url: "https://discord.com/channels/999999999999999999/999999999999999999",
+        createdAt: new Date(),
+      };
+
+      const updatedChannel = {
+        ...mockChannelCompleteData,
+        name: "main-hall",
+      };
+
+      channelRepository.findByPlatformId.mockResolvedValue(
+        mockChannelCompleteData,
+      );
+      channelRepository.updateById.mockResolvedValue(updatedChannel);
+
+      const result = await updateChannelCase.execute(
+        platformId,
+        channelChangedData,
+      );
+
+      expect(result).toEqual({
+        success: true,
+        data: updatedChannel,
+      });
+
+      expect(channelRepository.updateById).toHaveBeenCalledTimes(1);
+      expect(channelRepository.updateById).toHaveBeenCalledWith(
+        id,
+        channelChangedData,
+      );
+    });
+
+    it("should returns a not found response when channel not found", async () => {
+      const id = 1;
+      const channelChangedData = {
+        platformId: "1234567890",
+        name: "main-hall",
+        url: "https://discord.com/channels/999999999999999999/999999999999999999",
+        createdAt: new Date(),
+      };
+
+      const result = await updateChannelCase.execute(id, channelChangedData);
+
+      expect(result).toEqual({
+        success: false,
+        data: null,
+        message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
+      });
+      expect(channelRepository.findById).toHaveBeenCalledTimes(1);
+      expect(channelRepository.findById).toHaveBeenCalledWith(id);
+      expect(channelRepository.updateById).not.toHaveBeenCalledTimes(1);
+    });
+
+    it("should return error when failing to update a channel", async () => {
+      const id = 1;
+      const errorMessage = `Channel not found with id ${id}`;
+      const channelChangedData = {
+        platformId: "1234567890",
+        name: "main-hall",
+        url: "https://discord.com/channels/999999999999999999/999999999999999999",
+        createdAt: new Date(),
+      };
+      channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
+      channelRepository.updateById.mockRejectedValue(new Error(errorMessage));
+
+      const result = await updateChannelCase.execute(id, channelChangedData);
+
+      expect(result).toEqual({
+        success: false,
+        data: null,
+        message: errorMessage,
+      });
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.ERROR,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `UpdateChannel.execute | ${errorMessage}`,
+      );
+    });
+  });
+
+  describe("deleteChannel", () => {
+    it("should delete a channel", async () => {
+      const id = 1;
+      channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
+      channelRepository.deleteById.mockResolvedValue(true);
+
+      const result = await deleteChannelCase.execute(id);
+
+      expect(result).toEqual({
+        success: true,
+        data: true,
+      });
+
+      expect(channelRepository.deleteById).toHaveBeenCalledTimes(1);
+      expect(channelRepository.deleteById).toHaveBeenCalledWith(id);
+    });
+
+    it("should update a channel by platformId", async () => {
+      const platformId = "1234567890";
+
+      channelRepository.findByPlatformId.mockResolvedValue(
+        mockChannelCompleteData,
+      );
+      channelRepository.deleteById.mockResolvedValue(true);
+
+      const result = await deleteChannelCase.execute(platformId);
+
+      expect(result).toEqual({
+        success: true,
+        data: true,
+      });
+
+      expect(channelRepository.deleteById).toHaveBeenCalledTimes(1);
+      expect(channelRepository.deleteById).toHaveBeenCalledWith(
+        mockChannelCompleteData.id,
+      );
+    });
+
+    it("should returns a not found response when channel not found", async () => {
+      const id = 1;
+
+      const result = await deleteChannelCase.execute(id);
+
+      expect(result).toEqual({
+        success: false,
+        data: null,
+        message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
+      });
+      expect(channelRepository.findById).toHaveBeenCalledTimes(1);
+      expect(channelRepository.findById).toHaveBeenCalledWith(id);
+      expect(channelRepository.deleteById).not.toHaveBeenCalledTimes(1);
+    });
+
+    it("should return error when failing to delete a channel", async () => {
+      const id = 1;
+      const errorMessage = `Channel not found with id ${id}`;
+      channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
+      channelRepository.deleteById.mockRejectedValue(new Error(errorMessage));
+
+      const result = await deleteChannelCase.execute(id);
+
+      expect(result).toEqual({
+        success: false,
+        data: false,
+        message: errorMessage,
+      });
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.ERROR,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `DeleteChannel.execute | ${errorMessage}`,
+      );
+    });
+  });
+});

--- a/src/tests/channel/channelUseCases.test.ts
+++ b/src/tests/channel/channelUseCases.test.ts
@@ -1,5 +1,4 @@
 import { ILoggerService } from "@domain/interfaces/services/ILogger";
-import { ErrorMessages } from "@domain/types/ErrorMessages";
 import {
   LoggerContext,
   LoggerContextEntity,
@@ -52,17 +51,17 @@ describe("Channel useCases", () => {
   describe("createChannel", () => {
     it("should create a new channel", async () => {
       const mockChannel = { ...mockChannelValue, ...mockChannelId };
-      const mockResponse = {
-        success: true,
-        data: mockChannel,
-        message: "Channel saved successfully",
-      };
 
       channelRepository.create.mockResolvedValue(mockChannel);
 
-      const result = await createChannelCase.execute(mockChannelValue);
+      await createChannelCase.execute(mockChannelValue);
 
-      expect(result).toEqual(mockResponse);
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Channel ${mockChannel.id} - ${mockChannel.name} saved successfully`,
+      );
       expect(channelRepository.create).toHaveBeenCalledTimes(1);
       expect(channelRepository.create).toHaveBeenCalledWith({
         ...mockChannelValue,
@@ -79,8 +78,8 @@ describe("Channel useCases", () => {
       expect(result).toBeUndefined();
       expect(loggerMock.logToConsole).toHaveBeenCalledWith(
         LoggerContextStatus.ERROR,
-        LoggerContext.COMMAND,
-        LoggerContextEntity.USER,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
         `executeCreateChannel | ${errorMessage}`,
       );
     });
@@ -104,13 +103,14 @@ describe("Channel useCases", () => {
       channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
       channelRepository.updateById.mockResolvedValue(updatedChannel);
 
-      const result = await updateChannelCase.execute(id, channelChangedData);
+      await updateChannelCase.execute(id, channelChangedData);
 
-      expect(result).toEqual({
-        success: true,
-        data: updatedChannel,
-      });
-
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Channel ${updatedChannel.id} - ${updatedChannel.name} has been updated`,
+      );
       expect(channelRepository.updateById).toHaveBeenCalledTimes(1);
       expect(channelRepository.updateById).toHaveBeenCalledWith(
         id,
@@ -138,16 +138,14 @@ describe("Channel useCases", () => {
       );
       channelRepository.updateById.mockResolvedValue(updatedChannel);
 
-      const result = await updateChannelCase.execute(
-        platformId,
-        channelChangedData,
+      await updateChannelCase.execute(platformId, channelChangedData);
+
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Channel ${updatedChannel.id} - ${updatedChannel.name} has been updated`,
       );
-
-      expect(result).toEqual({
-        success: true,
-        data: updatedChannel,
-      });
-
       expect(channelRepository.updateById).toHaveBeenCalledTimes(1);
       expect(channelRepository.updateById).toHaveBeenCalledWith(
         id,
@@ -164,13 +162,8 @@ describe("Channel useCases", () => {
         createdAt: new Date(),
       };
 
-      const result = await updateChannelCase.execute(id, channelChangedData);
+      await updateChannelCase.execute(id, channelChangedData);
 
-      expect(result).toEqual({
-        success: false,
-        data: null,
-        message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
-      });
       expect(channelRepository.findById).toHaveBeenCalledTimes(1);
       expect(channelRepository.findById).toHaveBeenCalledWith(id);
       expect(channelRepository.updateById).not.toHaveBeenCalledTimes(1);
@@ -188,13 +181,8 @@ describe("Channel useCases", () => {
       channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
       channelRepository.updateById.mockRejectedValue(new Error(errorMessage));
 
-      const result = await updateChannelCase.execute(id, channelChangedData);
+      await updateChannelCase.execute(id, channelChangedData);
 
-      expect(result).toEqual({
-        success: false,
-        data: null,
-        message: errorMessage,
-      });
       expect(loggerMock.logToConsole).toHaveBeenCalledWith(
         LoggerContextStatus.ERROR,
         LoggerContext.USECASE,
@@ -210,13 +198,14 @@ describe("Channel useCases", () => {
       channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
       channelRepository.deleteById.mockResolvedValue(true);
 
-      const result = await deleteChannelCase.execute(id);
+      await deleteChannelCase.execute(id);
 
-      expect(result).toEqual({
-        success: true,
-        data: true,
-      });
-
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Was channel ${mockChannelCompleteData.id} - ${mockChannelCompleteData.name} deleted: ${true}`,
+      );
       expect(channelRepository.deleteById).toHaveBeenCalledTimes(1);
       expect(channelRepository.deleteById).toHaveBeenCalledWith(id);
     });
@@ -229,13 +218,14 @@ describe("Channel useCases", () => {
       );
       channelRepository.deleteById.mockResolvedValue(true);
 
-      const result = await deleteChannelCase.execute(platformId);
+      await deleteChannelCase.execute(platformId);
 
-      expect(result).toEqual({
-        success: true,
-        data: true,
-      });
-
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Was channel ${mockChannelCompleteData.id} - ${mockChannelCompleteData.name} deleted: ${true}`,
+      );
       expect(channelRepository.deleteById).toHaveBeenCalledTimes(1);
       expect(channelRepository.deleteById).toHaveBeenCalledWith(
         mockChannelCompleteData.id,
@@ -245,13 +235,8 @@ describe("Channel useCases", () => {
     it("should returns a not found response when channel not found", async () => {
       const id = 1;
 
-      const result = await deleteChannelCase.execute(id);
+      await deleteChannelCase.execute(id);
 
-      expect(result).toEqual({
-        success: false,
-        data: null,
-        message: `${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
-      });
       expect(channelRepository.findById).toHaveBeenCalledTimes(1);
       expect(channelRepository.findById).toHaveBeenCalledWith(id);
       expect(channelRepository.deleteById).not.toHaveBeenCalledTimes(1);
@@ -263,13 +248,8 @@ describe("Channel useCases", () => {
       channelRepository.findById.mockResolvedValue(mockChannelCompleteData);
       channelRepository.deleteById.mockRejectedValue(new Error(errorMessage));
 
-      const result = await deleteChannelCase.execute(id);
+      await deleteChannelCase.execute(id);
 
-      expect(result).toEqual({
-        success: false,
-        data: false,
-        message: errorMessage,
-      });
       expect(loggerMock.logToConsole).toHaveBeenCalledWith(
         LoggerContextStatus.ERROR,
         LoggerContext.USECASE,

--- a/src/tests/channel/repository.test.ts
+++ b/src/tests/channel/repository.test.ts
@@ -40,7 +40,7 @@ describe("ChannelRepository", () => {
       expect(prismaMock.channel.findUnique).toHaveBeenCalledWith({
         where: { id },
         include: {
-          user_channel: { include: { user: true } },
+          users: true,
           message: true,
           message_reaction: true,
         },
@@ -95,7 +95,7 @@ describe("ChannelRepository", () => {
       expect(prismaMock.channel.findFirst).toHaveBeenCalledWith({
         where: { platform_id: platformId },
         include: {
-          user_channel: { include: { user: true } },
+          users: true,
           message: true,
           message_reaction: true,
         },
@@ -103,7 +103,7 @@ describe("ChannelRepository", () => {
 
       const expectedEntity = ChannelEntity.fromPersistence(
         mockDbChannelValue,
-        mockDbChannelValue.user_channel.map((uc) => uc.user),
+        mockDbChannelValue.users,
         mockDbChannelValue.message,
         mockDbChannelValue.message_reaction,
       );
@@ -120,7 +120,7 @@ describe("ChannelRepository", () => {
       expect(prismaMock.channel.findFirst).toHaveBeenCalledWith({
         where: { platform_id: platformId },
         include: {
-          user_channel: { include: { user: true } },
+          users: true,
           message: true,
           message_reaction: true,
         },
@@ -155,11 +155,7 @@ describe("ChannelRepository", () => {
         name: channelData.name,
         url: channelData.url,
         created_at: channelData.createdAt,
-        user_channel: [
-          {
-            user: mockUserEntity,
-          },
-        ],
+        users: [mockUserEntity],
         message: [mockMessageEntity],
         message_reaction: [],
       };
@@ -183,18 +179,16 @@ describe("ChannelRepository", () => {
           message_reaction: {
             connect: [],
           },
-          user_channel: {
-            create: channelData.user.map((user) => ({
-              user: { connect: { platform_id: user.platformId } },
+          users: {
+            connect: channelData.user.map((user) => ({
+              platform_id: user.platformId,
             })),
           },
         },
         include: {
           message: true,
           message_reaction: true,
-          user_channel: {
-            include: { user: true },
-          },
+          users: true,
         },
       });
 
@@ -267,7 +261,7 @@ describe("ChannelRepository", () => {
       const dbChannels = [
         {
           ...mockDbChannelValue,
-          user_channel: [{ user: mockDBUserValue }],
+          users: [mockDBUserValue],
           message: [
             {
               ...mockDbMessageValue,
@@ -282,7 +276,7 @@ describe("ChannelRepository", () => {
           ...mockDbChannelValue,
           id: 2,
           platform_id: "discordId2",
-          user_channel: [{ user: mockDBUserValue }],
+          users: [mockDBUserValue],
           message: [
             {
               ...mockDbMessageValue,
@@ -303,11 +297,7 @@ describe("ChannelRepository", () => {
         where: {},
         take: undefined,
         include: {
-          user_channel: {
-            include: {
-              user: true,
-            },
-          },
+          users: true,
           message: true,
           message_reaction: true,
         },
@@ -336,7 +326,7 @@ describe("ChannelRepository", () => {
       const dbChannels = [
         {
           ...mockDbChannelValue,
-          user_channel: [{ user: mockDBUserValue }],
+          users: [mockDBUserValue],
           message: [
             {
               ...mockDbMessageValue,
@@ -358,11 +348,7 @@ describe("ChannelRepository", () => {
         where: {},
         take: 1,
         include: {
-          user_channel: {
-            include: {
-              user: true,
-            },
-          },
+          users: true,
           message: true,
           message_reaction: true,
         },

--- a/src/tests/config/constants.ts
+++ b/src/tests/config/constants.ts
@@ -43,8 +43,8 @@ export const mockDBUserValue = {
   email: undefined,
   message: [],
   message_reaction: [],
-  user_channel: [],
-  user_role: [],
+  channels: [],
+  roles: [],
   audio_event: [],
 } as unknown as naturalizeUser;
 
@@ -215,11 +215,7 @@ export const mockDbChannelValue = {
   created_at: new Date(),
   name: "channelName",
   url: "channelUrl",
-  user_channel: [
-    {
-      user: mockDBUserValue,
-    },
-  ],
+  users: [mockDBUserValue],
   message: [mockDbMessageValue],
   message_reaction: [],
 };
@@ -327,7 +323,7 @@ export const mockDBRoleValue = {
   name: "dev",
   created_at: new Date("2025-01-01"),
   platform_created_at: new Date("2025-01-01"),
-  user_role: [{ user: mockDBUserValue }],
+  users: [mockDBUserValue],
 };
 
 /**
@@ -363,7 +359,7 @@ export function createMockDbChannel(overrides: Partial<Channel> = {}): Channel {
     created_at: new Date("2023-01-01"),
     message: [],
     user_reaction: [],
-    user_channel: [],
+    users: [],
     ...overrides,
   } as Channel;
 }

--- a/src/tests/message/useCases/RegisterMessage.test.ts
+++ b/src/tests/message/useCases/RegisterMessage.test.ts
@@ -1,0 +1,372 @@
+import { RegisterMessage } from "@domain/useCases/message/RegisterMessage";
+import { IMessageRepository } from "@repositories/IMessageRepository";
+import { IUserRepository } from "@repositories/IUserRepository";
+import { IChannelRepository } from "@repositories/IChannelRepository";
+import { ICreateUser } from "@interfaces/useCases/user/ICreateUser";
+import { ILoggerService } from "@services/ILogger";
+import { UserStatus } from "@type/UserStatusEnum";
+import {
+  createMockUserEntity,
+  createMockChannelEntity,
+  createMockMessageEntity,
+} from "@tests/config/constants";
+
+describe("RegisterMessage", () => {
+  let registerMessage: RegisterMessage;
+  let mockMessageRepository: jest.Mocked<IMessageRepository>;
+  let mockUserRepository: jest.Mocked<IUserRepository>;
+  let mockChannelRepository: jest.Mocked<IChannelRepository>;
+  let mockCreateUser: jest.Mocked<ICreateUser>;
+  let mockLogger: jest.Mocked<ILoggerService>;
+
+  const mockChannel = createMockChannelEntity({
+    id: 1,
+    platformId: "channel123",
+    name: "Test Channel",
+    url: "https://discord.com/channels/123/channel123",
+  });
+
+  const mockUser = createMockUserEntity({
+    id: 1,
+    platformId: "user123",
+    username: "Test User",
+    bot: false,
+    status: UserStatus.ACTIVE,
+  });
+
+  const mockMessage = createMockMessageEntity({
+    id: 1,
+    platformId: "message123",
+    channel: mockChannel,
+    user: mockUser,
+    platformCreatedAt: new Date(),
+    isDeleted: false,
+    messageReactions: [],
+  });
+
+  beforeEach(() => {
+    mockMessageRepository = {
+      create: jest.fn(),
+      createMany: jest.fn(),
+      findById: jest.fn(),
+      findByPlatformId: jest.fn(),
+      findByChannelId: jest.fn(),
+      findByUserId: jest.fn(),
+      listAll: jest.fn(),
+      updateById: jest.fn(),
+      deleteById: jest.fn(),
+    };
+
+    mockUserRepository = {
+      create: jest.fn(),
+      createMany: jest.fn(),
+      findById: jest.fn(),
+      findByPlatformId: jest.fn(),
+      listAll: jest.fn(),
+      updateById: jest.fn(),
+      deleteById: jest.fn(),
+    };
+
+    mockChannelRepository = {
+      create: jest.fn(),
+      createMany: jest.fn(),
+      findById: jest.fn(),
+      findByPlatformId: jest.fn(),
+      listAll: jest.fn(),
+      updateById: jest.fn(),
+      deleteById: jest.fn(),
+    };
+
+    mockCreateUser = {
+      execute: jest.fn(),
+      executeMany: jest.fn(),
+    };
+
+    mockLogger = {
+      logToConsole: jest.fn(),
+      logToDatabase: jest.fn(),
+    };
+
+    registerMessage = new RegisterMessage(
+      mockMessageRepository,
+      mockUserRepository,
+      mockChannelRepository,
+      mockCreateUser,
+      mockLogger,
+    );
+  });
+
+  describe("execute", () => {
+    it("should successfully register a message when user and channel exist", async () => {
+      const input = {
+        platformId: "message123",
+        platformCreatedAt: new Date(),
+        channelId: "channel123",
+        userId: "user123",
+      };
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(mockUser);
+      mockChannelRepository.findByPlatformId.mockResolvedValue(mockChannel);
+      mockMessageRepository.findByPlatformId.mockRejectedValue(
+        new Error("Not found"),
+      );
+      mockMessageRepository.create.mockResolvedValue(mockMessage);
+
+      const result = await registerMessage.execute(input);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(mockMessage);
+      expect(mockUserRepository.findByPlatformId).toHaveBeenCalledWith(
+        "user123",
+        true,
+      );
+      expect(mockChannelRepository.findByPlatformId).toHaveBeenCalledWith(
+        "channel123",
+      );
+      expect(mockMessageRepository.create).toHaveBeenCalledWith({
+        platformId: input.platformId,
+        platformCreatedAt: input.platformCreatedAt,
+        isDeleted: false,
+        channel: mockChannel,
+        user: mockUser,
+        messageReactions: [],
+      });
+      expect(mockLogger.logToConsole).toHaveBeenCalledWith(
+        "SUCCESS",
+        "USECASE",
+        "MESSAGE",
+        `Message registered successfully: ${input.platformId}`,
+      );
+    });
+
+    it("should create user automatically if user does not exist", async () => {
+      const input = {
+        platformId: "message123",
+        platformCreatedAt: new Date(),
+        channelId: "channel123",
+        userId: "user123",
+        username: "New User",
+        userBot: false,
+        userGlobalName: "New User Global",
+      };
+
+      const createdUser = createMockUserEntity({
+        id: 1,
+        platformId: "user123",
+        username: "New User",
+        bot: false,
+        status: UserStatus.ACTIVE,
+      });
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(null);
+      mockCreateUser.execute.mockResolvedValue({
+        success: true,
+        data: createdUser,
+      });
+      mockChannelRepository.findByPlatformId.mockResolvedValue(mockChannel);
+      mockMessageRepository.findByPlatformId.mockRejectedValue(
+        new Error("Not found"),
+      );
+      mockMessageRepository.create.mockResolvedValue(mockMessage);
+
+      const result = await registerMessage.execute(input);
+
+      expect(result.success).toBe(true);
+      expect(mockCreateUser.execute).toHaveBeenCalledWith({
+        platformId: input.userId,
+        username: input.username,
+        globalName: input.userGlobalName || null,
+        bot: input.userBot || false,
+        status: UserStatus.ACTIVE,
+        platformCreatedAt: undefined,
+        joinedAt: null,
+        lastActive: undefined,
+      });
+      expect(mockMessageRepository.create).toHaveBeenCalled();
+    });
+
+    it("should create channel automatically if channel does not exist", async () => {
+      const input = {
+        platformId: "message123",
+        platformCreatedAt: new Date(),
+        channelId: "channel123",
+        userId: "user123",
+        channelName: "New Channel",
+        channelUrl: "https://discord.com/channels/123/channel123",
+      };
+
+      const createdChannel = createMockChannelEntity({
+        id: 1,
+        platformId: "channel123",
+        name: "New Channel",
+        url: "https://discord.com/channels/123/channel123",
+      });
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(mockUser);
+      mockChannelRepository.findByPlatformId.mockResolvedValue(null);
+      mockChannelRepository.create.mockResolvedValue(createdChannel);
+      mockMessageRepository.findByPlatformId.mockRejectedValue(
+        new Error("Not found"),
+      );
+      mockMessageRepository.create.mockResolvedValue(mockMessage);
+
+      const result = await registerMessage.execute(input);
+
+      expect(result.success).toBe(true);
+      expect(mockChannelRepository.create).toHaveBeenCalledWith({
+        platformId: input.channelId,
+        name: input.channelName,
+        url: input.channelUrl,
+        createdAt: expect.any(Date),
+      });
+      expect(mockMessageRepository.create).toHaveBeenCalled();
+    });
+
+    it("should return error when user data is missing for user creation", async () => {
+      const input = {
+        platformId: "message123",
+        platformCreatedAt: new Date(),
+        channelId: "channel123",
+        userId: "user123",
+      };
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(null);
+
+      const result = await registerMessage.execute(input);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("User data required for user creation");
+      expect(mockCreateUser.execute).not.toHaveBeenCalled();
+      expect(mockMessageRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("should return error when message already exists", async () => {
+      const input = {
+        platformId: "message123",
+        platformCreatedAt: new Date(),
+        channelId: "channel123",
+        userId: "user123",
+      };
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(mockUser);
+      mockChannelRepository.findByPlatformId.mockResolvedValue(mockChannel);
+      mockMessageRepository.findByPlatformId.mockResolvedValue(mockMessage);
+
+      const result = await registerMessage.execute(input);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Message already exists");
+      expect(result.data).toEqual(mockMessage);
+      expect(mockMessageRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("should return error when message creation fails", async () => {
+      const input = {
+        platformId: "message123",
+        platformCreatedAt: new Date(),
+        channelId: "channel123",
+        userId: "user123",
+      };
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(mockUser);
+      mockChannelRepository.findByPlatformId.mockResolvedValue(mockChannel);
+      mockMessageRepository.findByPlatformId.mockRejectedValue(
+        new Error("Not found"),
+      );
+      mockMessageRepository.create.mockResolvedValue(null);
+
+      const result = await registerMessage.execute(input);
+
+      expect(result.success).toBe(false);
+      expect(result.data).toBeNull();
+      expect(result.message).toBe("Unknown error occurred");
+    });
+
+    it("should handle repository errors and log them", async () => {
+      const input = {
+        platformId: "message123",
+        platformCreatedAt: new Date(),
+        channelId: "channel123",
+        userId: "user123",
+      };
+
+      const error = new Error("Database connection failed");
+      mockUserRepository.findByPlatformId.mockRejectedValue(error);
+
+      const result = await registerMessage.execute(input);
+
+      expect(result.success).toBe(false);
+      expect(result.data).toBeNull();
+      expect(result.message).toBe("Database connection failed");
+      expect(mockLogger.logToConsole).toHaveBeenCalledWith(
+        "ERROR",
+        "USECASE",
+        "MESSAGE",
+        "registerMessage.execute | Database connection failed",
+      );
+    });
+
+    it("should handle unknown errors gracefully", async () => {
+      const input = {
+        platformId: "message123",
+        platformCreatedAt: new Date(),
+        channelId: "channel123",
+        userId: "user123",
+      };
+
+      const error = "Unknown error type";
+      mockUserRepository.findByPlatformId.mockRejectedValue(error);
+
+      const result = await registerMessage.execute(input);
+
+      expect(result.success).toBe(false);
+      expect(result.data).toBeNull();
+      expect(result.message).toBe("Unknown error occurred");
+    });
+
+    it("should handle channel creation failure", async () => {
+      const input = {
+        platformId: "message123",
+        platformCreatedAt: new Date(),
+        channelId: "channel123",
+        userId: "user123",
+        channelName: "New Channel",
+        channelUrl: "https://discord.com/channels/123/channel123",
+      };
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(mockUser);
+      mockChannelRepository.findByPlatformId.mockResolvedValue(null);
+      mockChannelRepository.create.mockResolvedValue(null);
+
+      const result = await registerMessage.execute(input);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Failed to create channel");
+      expect(mockMessageRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("should handle user creation failure", async () => {
+      const input = {
+        platformId: "message123",
+        platformCreatedAt: new Date(),
+        channelId: "channel123",
+        userId: "user123",
+        username: "New User",
+        userBot: false,
+      };
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(null);
+      mockCreateUser.execute.mockResolvedValue({
+        success: false,
+        data: null,
+        message: "User creation failed",
+      });
+
+      const result = await registerMessage.execute(input);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("User creation failed");
+      expect(mockMessageRepository.create).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/tests/role/repository.test.ts
+++ b/src/tests/role/repository.test.ts
@@ -31,7 +31,7 @@ describe("RoleRepository", () => {
       expect(prismaMock.role.findUnique).toHaveBeenCalledTimes(1);
       expect(prismaMock.role.findUnique).toHaveBeenCalledWith({
         where: { id: mockDBRoleValue.id },
-        include: { user_role: { include: { user: true } } },
+        include: { users: true },
       });
 
       expect(role).toHaveProperty("id", 1);
@@ -41,9 +41,7 @@ describe("RoleRepository", () => {
       expect(role).toHaveProperty("platformCreatedAt", new Date("2025-01-01"));
       expect(role).toHaveProperty(
         "user",
-        mockDBRoleValue.user_role.map((userRole) =>
-          UserEntity.fromPersistence(userRole.user),
-        ),
+        mockDBRoleValue.users.map((user) => UserEntity.fromPersistence(user)),
       );
     });
 
@@ -58,7 +56,7 @@ describe("RoleRepository", () => {
       expect(prismaMock.role.findUnique).toHaveBeenCalledTimes(1);
       expect(prismaMock.role.findUnique).toHaveBeenCalledWith({
         where: { id: mockDBRoleValue.id },
-        include: { user_role: { include: { user: true } } },
+        include: { users: true },
       });
 
       expect(role).toBeUndefined();
@@ -90,9 +88,7 @@ describe("RoleRepository", () => {
       expect(role).toHaveProperty("platformCreatedAt", new Date("2025-01-01"));
       expect(role).toHaveProperty(
         "user",
-        mockDBRoleValue.user_role.map((userRole) =>
-          UserEntity.fromPersistence(userRole.user),
-        ),
+        mockDBRoleValue.users.map((user) => UserEntity.fromPersistence(user)),
       );
     });
     it("should return null if role not found", async () => {
@@ -115,7 +111,7 @@ describe("RoleRepository", () => {
       expect(prismaMock.role.findUnique).toHaveBeenCalledTimes(1);
       expect(prismaMock.role.findUnique).toHaveBeenCalledWith({
         where: { platform_id: mockDBRoleValue.platform_id },
-        include: { user_role: { include: { user: true } } },
+        include: { users: true },
       });
       expect(role).toHaveProperty("id", 1);
       expect(role).toHaveProperty("platformId", "1");
@@ -124,9 +120,7 @@ describe("RoleRepository", () => {
       expect(role).toHaveProperty("platformCreatedAt", new Date("2025-01-01"));
       expect(role).toHaveProperty(
         "user",
-        mockDBRoleValue.user_role.map((userRole) =>
-          UserEntity.fromPersistence(userRole.user),
-        ),
+        mockDBRoleValue.users.map((user) => UserEntity.fromPersistence(user)),
       );
     });
     it("should return null if role not found", async () => {
@@ -138,7 +132,7 @@ describe("RoleRepository", () => {
       expect(prismaMock.role.findUnique).toHaveBeenCalledTimes(1);
       expect(prismaMock.role.findUnique).toHaveBeenCalledWith({
         where: { platform_id: platform_id },
-        include: { user_role: { include: { user: true } } },
+        include: { users: true },
       });
       expect(role).toBeUndefined();
     });


### PR DESCRIPTION
## Descrição

Atualizando branch de produção com alterações das seguintes atividades:
- [CPDD-239](https://www.notion.so/cpdd/useCases-Mensagens-Registrar-evento-do-discord-de-nova-mensagem-1f2c5f6d25f880449c31dc87a898a106?source=copy_link): Criar entrada na tabela de Mensagens ao envio de novas mensagens no servidor 
- [CPDD-241](https://www.notion.so/cpdd/useCases-Canais-Registrar-evento-do-discord-de-cria-o-de-canal-1f2c5f6d25f88053975ccd3c512ed9c0?source=copy_link): Registrar entrada na tabela de canal quando novo canal for criado, e fazer deleção quando o canal for apagado
- [CPDD-512](https://www.notion.so/cpdd/D-bito-t-cnico-Alterar-modelagem-expl-cita-para-impl-cita-em-tabelas-de-relacionamento-27fc5f6d25f88081b07dc1b5da15c439?source=copy_link): (Débito técnico) Usar relacionamento M:N implícito do Prisma

## Link da tarefa

- [CPDD-239](https://www.notion.so/cpdd/useCases-Mensagens-Registrar-evento-do-discord-de-nova-mensagem-1f2c5f6d25f880449c31dc87a898a106?source=copy_link)
- [CPDD-241](https://www.notion.so/cpdd/useCases-Canais-Registrar-evento-do-discord-de-cria-o-de-canal-1f2c5f6d25f88053975ccd3c512ed9c0?source=copy_link)
- [CPDD-512](https://www.notion.so/cpdd/D-bito-t-cnico-Alterar-modelagem-expl-cita-para-impl-cita-em-tabelas-de-relacionamento-27fc5f6d25f88081b07dc1b5da15c439?source=copy_lin

## Tipo de mudança

- [ ] Bugfix
- [x] Nova funcionalidade
- [x] Refatoração
- [ ] Documentação

## Como foi testado?

- CPDD-512: Reset do banco e rodando as migrações novamente, garantindo que está usando novo mapeamento
- CPDD-241: através de criação e deleção de novos canais, de todos os tipos, inclusive canais privados
- CPDD-239: através de envio de mensagens no canal `#chat-geral` do servidor de testes

## Checklist

- [x] Código segue o padrão de estilo do projeto
- [x] Testes unitários foram adicionados
- [ ] A documentação foi atualizada (se aplicável)
