### PR TITLE
CPDD-126 | Correção no Listener de Event Update

### DIFF
--- a/src/infrastructure/discord/DiscordService.ts
+++ b/src/infrastructure/discord/DiscordService.ts
@@ -83,8 +83,8 @@ export class DiscordService
       this.onDeleteChannelHandlers.forEach((fn) => fn(<GuildChannel>channel));
     });
 
-    this.client.on(Events.GuildScheduledEventUpdate, (event) => {
-      this.onVoiceEventHandlers.forEach((fn) => fn(event));
+    this.client.on(Events.GuildScheduledEventUpdate, (_oldEvent, newEvent) => {
+      this.onVoiceEventHandlers.forEach((fn) => fn(newEvent));
     });
 
     this.client.on(Events.GuildScheduledEventCreate, (event) => {


### PR DESCRIPTION
## Descrição

Listener do GuildScheduledEventUpdate no DiscordService estava pegando o primeiro parâmetro, que era o estado antigo do evento (oldEvent) em vez do estado atualizado (newEvent).
Isto fazia o audio_event ser salvo na tabela apenas quando sofria alguma alteração como ser cancelado ou encerrado, e nunca salvava endDate na tabela.

## Link da tarefa

[CPDD-126](https://www.notion.so/cpdd/useCases-FinalizeVoiceEvent-Salvar-informa-es-ao-sair-do-evento-311c5f6d25f8803f8c24fb312c53c0dc?source=copy_link)

## Tipo de mudança

- [x] Bugfix
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

## Como foi testado?

Testado localmente em servidor local.

## Checklist

- [x] Código segue o padrão de estilo do projeto
- [ ] Testes unitários foram adicionados
- [ ] A documentação foi atualizada (se aplicável)
