### PR TITLE
CPDD-130 - Atualiza cargos do usuario quando tem mudancas nos cargos

### DIFF
--- a/src/application/command/roleUpdateCommand.ts
+++ b/src/application/command/roleUpdateCommand.ts
@@ -1,0 +1,78 @@
+import { IDiscordService } from "@services/IDiscordService";
+import { ILoggerService } from "@services/ILogger";
+import { IRoleUpdateCommand } from "@interfaces/commands/IRoleUpdateCommand";
+import { IUpdateUserRole } from "@interfaces/useCases/role/IUpdateUserRole";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "@type/LoggerContextEnum";
+import { Client, GuildMember, Message, PartialGuildMember } from "discord.js";
+
+export class RoleUpdateCommand implements IRoleUpdateCommand {
+  constructor(
+    private readonly discordService: IDiscordService<
+      Message,
+      GuildMember,
+      PartialGuildMember,
+      Client
+    >,
+    private readonly logger: ILoggerService,
+    private readonly updateUserRole: IUpdateUserRole,
+  ) {
+    this.executeRoleUpdate();
+  }
+
+  async executeRoleUpdate(): Promise<void> {
+    try {
+      this.discordService.onMemberUpdate(async (oldMember, newMember) => {
+        if (newMember.user.bot) {
+          return;
+        }
+
+        const currentRoles = newMember.roles.cache
+          .filter((role) => role.id !== newMember.guild.id)
+          .map((role) => ({
+            platformId: role.id,
+            name: role.name,
+            platformCreatedAt: role.createdAt,
+          }));
+
+        const result = await this.updateUserRole.syncUserRoles({
+          userPlatformId: newMember.id,
+          username: newMember.user.username,
+          userGlobalName: newMember.user.globalName,
+          userBot: newMember.user.bot,
+          userPlatformCreatedAt: newMember.user.createdAt,
+          userJoinedAt: newMember.joinedAt,
+          roles: currentRoles,
+        });
+
+        if (result.success && result.data) {
+          const { added, removed, total, isNewUser } = result.data;
+          const userStatus = isNewUser ? "(novo usuario)" : "";
+          this.logger.logToConsole(
+            LoggerContextStatus.SUCCESS,
+            LoggerContext.COMMAND,
+            LoggerContextEntity.ROLE,
+            `${newMember.user.tag} ${userStatus} | +${added} -${removed} = ${total} cargos`,
+          );
+        } else {
+          this.logger.logToConsole(
+            LoggerContextStatus.ERROR,
+            LoggerContext.COMMAND,
+            LoggerContextEntity.ROLE,
+            `Falha ao sincronizar cargos para ${newMember.user.tag}: ${result.message}`,
+          );
+        }
+      });
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.ROLE,
+        `executeRoleUpdate | ${error.message}`,
+      );
+    }
+  }
+}

--- a/src/contexts/app.context.ts
+++ b/src/contexts/app.context.ts
@@ -1,5 +1,6 @@
 import { ChannelCommand } from "@application/command/channelCommand";
 import { MessageCommand } from "@application/command/messageCommand";
+import { RoleUpdateCommand } from "@application/command/roleUpdateCommand";
 import { UserCommand } from "@application/command/userCommand";
 import { VoiceEventCommand } from "@application/command/voiceEventCommand";
 import { Logger } from "@application/services/Logger";
@@ -16,6 +17,7 @@ import { initializeMessageUseCases } from "./useMessageCases.context";
 import { initializeUserUseCases } from "./useUserCases.context";
 import { initializeVoiceEventUseCases } from "./useVoiceEventCases.context";
 import { initializeUserEventUseCases } from "@contexts/userEventUseCases.context";
+import { initializeRoleUseCases } from "@contexts/useRoleCases.context";
 import { UserEventCommand } from "@application/command/userEventCommand";
 
 export function initializeApp() {
@@ -27,6 +29,7 @@ export function initializeApp() {
     audioEventRepository,
     messageRepository,
     channelRepository,
+    roleRepository,
   } = initializeDatabase(logger);
   const { discordService } = initializeDiscord();
   const { TOKEN_BOT } = process.env;
@@ -64,6 +67,12 @@ export function initializeApp() {
     userUseCases.createUserCase,
     logger,
   );
+  const roleUseCases = initializeRoleUseCases(
+    roleRepository,
+    userRepository,
+    userUseCases.createUserCase,
+    logger,
+  );
 
   // E finalmente as inicializacoes da aplicacao
   new UserCommand(
@@ -86,6 +95,12 @@ export function initializeApp() {
   );
 
   new MessageCommand(discordService, logger, registerMessage);
+
+  new RoleUpdateCommand(
+    discordService,
+    logger,
+    roleUseCases.updateUserRoleCase,
+  );
 
   // Isso deve ser executado depois que o user command for iniciado
   discordService.registerEvents();

--- a/src/contexts/database.context.ts
+++ b/src/contexts/database.context.ts
@@ -3,6 +3,7 @@ import { UserRepository } from "@infra/repositories/UserRepository";
 import { MessageRepository } from "@infra/persistence/repositories/MessageRepository";
 import { IMessageReactionRepository } from "@domain/interfaces/repositories/IMessageReactionRepository";
 import { MessageReactionRepository } from "@infra/persistence/repositories/MessageReactionRepository";
+import { RoleRepository } from "@infra/persistence/repositories/RoleRepository";
 
 import { IUserRepository } from "@repositories/IUserRepository";
 import { PrismaClient } from "@prisma/client";
@@ -14,6 +15,7 @@ import { AudioEventRepository } from "@infra/repositories/AudioEventRepository";
 import { IAudioEventRepository } from "@domain/interfaces/repositories/IAudioEventRepository";
 import { IUserEventRepository } from "@repositories/IUserEventRepository";
 import { UserEventRepository } from "@infra/repositories/UserEventRepository";
+import { IRoleRepository } from "@repositories/IRoleRepository";
 
 /**
  * Inicializa e configura o banco de dados.
@@ -35,6 +37,7 @@ export function initializeDatabase(
   channelRepository: IChannelRepository;
   audioEventRepository: IAudioEventRepository;
   userEventRepository: IUserEventRepository;
+  roleRepository: IRoleRepository;
 } {
   const prismaClient = new PrismaClient();
   const newPrismaService = new PrismaService(prismaClient);
@@ -63,6 +66,10 @@ export function initializeDatabase(
     prismaService ?? newPrismaService,
     logger,
   );
+  const roleRepository = new RoleRepository(
+    prismaService ?? newPrismaService,
+    logger,
+  );
 
   return {
     userRepository,
@@ -71,5 +78,6 @@ export function initializeDatabase(
     channelRepository,
     audioEventRepository,
     userEventRepository,
+    roleRepository,
   };
 }

--- a/src/contexts/discord.context.ts
+++ b/src/contexts/discord.context.ts
@@ -21,6 +21,10 @@ const EVENT_INTENTS_MAP: Partial<Record<Events, GatewayIntentBits[]>> = {
     GatewayIntentBits.GuildMembers,
     GatewayIntentBits.Guilds,
   ],
+  [Events.GuildMemberUpdate]: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMembers,
+  ],
   [Events.GuildScheduledEventUpdate]: [
     GatewayIntentBits.Guilds,
     GatewayIntentBits.GuildScheduledEvents,

--- a/src/contexts/useRoleCases.context.ts
+++ b/src/contexts/useRoleCases.context.ts
@@ -1,0 +1,26 @@
+import { IRoleRepository } from "@repositories/IRoleRepository";
+import { IUserRepository } from "@repositories/IUserRepository";
+import { ICreateUser } from "@interfaces/useCases/user/ICreateUser";
+import { ILoggerService } from "@services/ILogger";
+import { UpdateUserRole } from "@domain/useCases/role/UpdateUserRole";
+import { IUpdateUserRole } from "@interfaces/useCases/role/IUpdateUserRole";
+
+export function initializeRoleUseCases(
+  roleRepository: IRoleRepository,
+  userRepository: IUserRepository,
+  createUserCase: ICreateUser,
+  logger: ILoggerService,
+): {
+  updateUserRoleCase: IUpdateUserRole;
+} {
+  const updateUserRoleCase = new UpdateUserRole(
+    roleRepository,
+    userRepository,
+    createUserCase,
+    logger,
+  );
+
+  return {
+    updateUserRoleCase,
+  };
+}

--- a/src/domain/interfaces/commands/IRoleUpdateCommand.ts
+++ b/src/domain/interfaces/commands/IRoleUpdateCommand.ts
@@ -1,0 +1,3 @@
+export interface IRoleUpdateCommand {
+  executeRoleUpdate(): Promise<void>;
+}

--- a/src/domain/interfaces/repositories/IRoleRepository.ts
+++ b/src/domain/interfaces/repositories/IRoleRepository.ts
@@ -1,5 +1,7 @@
 import { RoleEntity } from "../../entities/Role";
 
+export type CreateRoleInput = Omit<RoleEntity, "id" | "createdAt" | "user">;
+
 export interface IRoleRepository {
   findById(id: number): Promise<RoleEntity | null>;
   findByUserPlatformId(id: string): Promise<RoleEntity[] | null>;
@@ -7,4 +9,13 @@ export interface IRoleRepository {
   listAll(limit?: number): Promise<RoleEntity[]>;
   updateById(id: number, role: Partial<RoleEntity>): Promise<RoleEntity | null>;
   deleteById(id: number): Promise<boolean>;
+  create(role: CreateRoleInput): Promise<RoleEntity>;
+  assignRoleToUser(
+    rolePlatformId: string,
+    userPlatformId: string,
+  ): Promise<boolean>;
+  removeRoleFromUser(
+    rolePlatformId: string,
+    userPlatformId: string,
+  ): Promise<boolean>;
 }

--- a/src/domain/interfaces/services/IDiscordService.ts
+++ b/src/domain/interfaces/services/IDiscordService.ts
@@ -12,6 +12,7 @@ export interface IDiscordService<
   onMessage(handler: (message: M) => void): void;
   onNewUser(handler: (member: U) => void): void;
   onUserLeave(handler: (member: U | P) => void): void;
+  onMemberUpdate(handler: (oldMember: U | P, newMember: U) => void): void;
   onVoiceEventUserChange(handler: (oldState: S, newState: S) => void): void;
   onVoiceEvent(handler: (event: E) => void): void;
   registerEvents(): void;

--- a/src/domain/interfaces/useCases/role/IUpdateUserRole.ts
+++ b/src/domain/interfaces/useCases/role/IUpdateUserRole.ts
@@ -1,0 +1,30 @@
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+
+export interface RoleInput {
+  platformId: string;
+  name: string;
+  platformCreatedAt: Date;
+}
+
+export interface SyncUserRolesInput {
+  userPlatformId: string;
+  username: string;
+  userGlobalName: string | null;
+  userBot: boolean;
+  userPlatformCreatedAt?: Date;
+  userJoinedAt?: Date | null;
+  roles: RoleInput[];
+}
+
+export interface SyncUserRolesResult {
+  added: number;
+  removed: number;
+  total: number;
+  isNewUser: boolean;
+}
+
+export interface IUpdateUserRole {
+  syncUserRoles(
+    input: SyncUserRolesInput,
+  ): Promise<GenericOutputDto<SyncUserRolesResult>>;
+}

--- a/src/domain/useCases/role/UpdateUserRole.ts
+++ b/src/domain/useCases/role/UpdateUserRole.ts
@@ -1,0 +1,156 @@
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+import { IRoleRepository } from "@repositories/IRoleRepository";
+import { IUserRepository } from "@repositories/IUserRepository";
+import { ICreateUser } from "@interfaces/useCases/user/ICreateUser";
+import { ILoggerService } from "@services/ILogger";
+import {
+  IUpdateUserRole,
+  RoleInput,
+  SyncUserRolesInput,
+  SyncUserRolesResult,
+} from "@interfaces/useCases/role/IUpdateUserRole";
+import { ErrorMessages } from "@type/ErrorMessages";
+import {
+  LoggerContextStatus,
+  LoggerContext,
+  LoggerContextEntity,
+} from "@type/LoggerContextEnum";
+import { UserStatus } from "@type/UserStatusEnum";
+
+export class UpdateUserRole implements IUpdateUserRole {
+  constructor(
+    private readonly roleRepository: IRoleRepository,
+    private readonly userRepository: IUserRepository,
+    private readonly createUser: ICreateUser,
+    private readonly logger: ILoggerService,
+  ) {}
+
+  async syncUserRoles(
+    input: SyncUserRolesInput,
+  ): Promise<GenericOutputDto<SyncUserRolesResult>> {
+    try {
+      const { isNew } = await this.ensureUserExists(input);
+
+      let added = 0;
+      let removed = 0;
+
+      if (isNew) {
+        added = await this.addRoles(input.userPlatformId, input.roles);
+      } else {
+        const result = await this.diffAndSyncRoles(
+          input.userPlatformId,
+          input.roles,
+        );
+        added = result.added;
+        removed = result.removed;
+      }
+
+      return {
+        data: {
+          added,
+          removed,
+          total: input.roles.length,
+          isNewUser: isNew,
+        },
+        success: true,
+      };
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.USECASE,
+        LoggerContextEntity.ROLE,
+        `UpdateUserRole.syncUserRoles | ${error.message}`,
+      );
+      return {
+        data: null,
+        success: false,
+        message:
+          error instanceof Error ? error.message : ErrorMessages.UNKNOWN_ERROR,
+      };
+    }
+  }
+
+  private async diffAndSyncRoles(
+    userPlatformId: string,
+    discordRoles: RoleInput[],
+  ): Promise<{ added: number; removed: number }> {
+    const dbRoles =
+      await this.roleRepository.findByUserPlatformId(userPlatformId);
+    const dbRoleIds = new Set(dbRoles?.map((r) => r.platformId) ?? []);
+    const discordRoleIds = new Set(discordRoles.map((r) => r.platformId));
+
+    // Cargos a adicionar: usuario tem mas nao temos registro
+    const toAdd = discordRoles.filter((r) => !dbRoleIds.has(r.platformId));
+
+    // Cargos a remover: temos no BD mas nao no discord
+    const toRemove =
+      dbRoles?.filter((r) => !discordRoleIds.has(r.platformId)) ?? [];
+
+    // Adiciona cargos
+    const added = await this.addRoles(userPlatformId, toAdd);
+
+    // Remove cargos
+    for (const role of toRemove) {
+      await this.roleRepository.removeRoleFromUser(
+        role.platformId,
+        userPlatformId,
+      );
+    }
+
+    return { added, removed: toRemove.length };
+  }
+
+  private async addRoles(
+    userPlatformId: string,
+    roles: RoleInput[],
+  ): Promise<number> {
+    let added = 0;
+    for (const role of roles) {
+      let dbRole = await this.roleRepository.findByPlatformId(role.platformId);
+      if (!dbRole) {
+        dbRole = await this.roleRepository.create({
+          platformId: role.platformId,
+          name: role.name,
+          platformCreatedAt: role.platformCreatedAt,
+        });
+      }
+
+      await this.roleRepository.assignRoleToUser(
+        role.platformId,
+        userPlatformId,
+      );
+      added++;
+    }
+    return added;
+  }
+
+  private async ensureUserExists(
+    input: SyncUserRolesInput,
+  ): Promise<{ isNew: boolean }> {
+    const user = await this.userRepository.findByPlatformId(
+      input.userPlatformId,
+      true,
+    );
+
+    if (user) {
+      return { isNew: false };
+    }
+
+    const createUserResult = await this.createUser.execute({
+      platformId: input.userPlatformId,
+      username: input.username,
+      globalName: input.userGlobalName,
+      bot: input.userBot,
+      status: UserStatus.ACTIVE,
+      platformCreatedAt: input.userPlatformCreatedAt,
+      joinedAt: input.userJoinedAt ?? undefined,
+      lastActive: undefined,
+    });
+
+    if (!createUserResult.success) {
+      throw new Error("Falha ao criar usuario: " + input.username);
+    }
+
+    return { isNew: true };
+  }
+}

--- a/src/infrastructure/discord/DiscordService.ts
+++ b/src/infrastructure/discord/DiscordService.ts
@@ -43,6 +43,10 @@ export class DiscordService
     oldState: VoiceState,
     newState: VoiceState,
   ) => void)[] = [];
+  private onMemberUpdateHandlers: ((
+    oldMember: GuildMember | PartialGuildMember,
+    newMember: GuildMember,
+  ) => void)[] = [];
 
   constructor(client: Client) {
     this.client = client;
@@ -67,6 +71,11 @@ export class DiscordService
     //caso de excessao, pois esse evento compartilha o intent com GuildMemberAdd
     this.client.on(Events.GuildMemberRemove, (member) => {
       this.onUserLeaveHandlers.forEach((fn) => fn(member));
+    });
+
+    //caso de excessao, pois esse evento compartilha o intent com GuildMemberAdd
+    this.client.on(Events.GuildMemberUpdate, (oldMember, newMember) => {
+      this.onMemberUpdateHandlers.forEach((fn) => fn(oldMember, newMember));
     });
 
     this.client.on(Events.ChannelCreate, (channel) => {
@@ -116,6 +125,15 @@ export class DiscordService
 
   public onUserLeave(handler: (member: GuildMember) => void): void {
     this.onUserLeaveHandlers.push(handler);
+  }
+
+  public onMemberUpdate(
+    handler: (
+      oldMember: GuildMember | PartialGuildMember,
+      newMember: GuildMember,
+    ) => void,
+  ): void {
+    this.onMemberUpdateHandlers.push(handler);
   }
 
   public onVoiceEventUserChange(

--- a/src/infrastructure/persistence/repositories/RoleRepository.ts
+++ b/src/infrastructure/persistence/repositories/RoleRepository.ts
@@ -1,5 +1,8 @@
 import { RoleEntity } from "@domain/entities/Role";
-import { IRoleRepository } from "@domain/interfaces/repositories/IRoleRepository";
+import {
+  CreateRoleInput,
+  IRoleRepository,
+} from "@domain/interfaces/repositories/IRoleRepository";
 import { ILoggerService } from "@domain/interfaces/services/ILogger";
 import {
   LoggerContext,
@@ -28,7 +31,9 @@ export class RoleRepository implements IRoleRepository {
         where: { id },
         include: { users: true },
       });
-
+      if (!result) {
+        return null;
+      }
       return PrismaMapper.toRoleEntity(result, result.users);
     } catch (error) {
       this.logger.logToConsole(
@@ -38,7 +43,9 @@ export class RoleRepository implements IRoleRepository {
         `findByIdRole | ${error.message}`,
       );
     }
+    return null;
   }
+
   async findByUserPlatformId(id: string): Promise<RoleEntity[] | null> {
     try {
       const result = await this.client.role.findMany({
@@ -54,13 +61,18 @@ export class RoleRepository implements IRoleRepository {
         `findByUserPlatformId | ${error.message}`,
       );
     }
+    return null;
   }
+
   async findByPlatformId(id: string): Promise<RoleEntity | null> {
     try {
       const result = await this.client.role.findUnique({
         where: { platform_id: id },
         include: { users: true },
       });
+      if (!result) {
+        return null;
+      }
       return PrismaMapper.toRoleEntity(result, result.users);
     } catch (error) {
       this.logger.logToConsole(
@@ -70,7 +82,9 @@ export class RoleRepository implements IRoleRepository {
         `findByPlatformId | ${error.message}`,
       );
     }
+    return null;
   }
+
   async listAll(limit?: number): Promise<RoleEntity[]> {
     try {
       const results = await this.client.role.findMany({
@@ -88,7 +102,9 @@ export class RoleRepository implements IRoleRepository {
         `listAll | ${error.message}`,
       );
     }
+    return [];
   }
+
   async updateById(
     id: number,
     role: Partial<RoleEntity>,
@@ -103,10 +119,11 @@ export class RoleRepository implements IRoleRepository {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
         LoggerContext.REPOSITORY,
-        LoggerContextEntity.USER,
+        LoggerContextEntity.ROLE,
         `updateById | ${error.message}`,
       );
     }
+    return null;
   }
 
   async deleteById(id: number): Promise<boolean> {
@@ -122,8 +139,79 @@ export class RoleRepository implements IRoleRepository {
         LoggerContextEntity.ROLE,
         `deleteRole | ${error.message}`,
       );
-      return false;
     }
+    return false;
+  }
+
+  async create(role: CreateRoleInput): Promise<RoleEntity> {
+    try {
+      const result = await this.client.role.create({
+        data: {
+          platform_id: role.platformId,
+          name: role.name,
+          platform_created_at: role.platformCreatedAt,
+        },
+      });
+      return PrismaMapper.toRoleEntity(result);
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.ROLE,
+        `create | ${error.message}`,
+      );
+      throw error;
+    }
+  }
+
+  async assignRoleToUser(
+    rolePlatformId: string,
+    userPlatformId: string,
+  ): Promise<boolean> {
+    try {
+      await this.client.role.update({
+        where: { platform_id: rolePlatformId },
+        data: {
+          users: {
+            connect: { platform_id: userPlatformId },
+          },
+        },
+      });
+      return true;
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.ROLE,
+        `assignRoleToUser | ${error.message}`,
+      );
+    }
+    return false;
+  }
+
+  async removeRoleFromUser(
+    rolePlatformId: string,
+    userPlatformId: string,
+  ): Promise<boolean> {
+    try {
+      await this.client.role.update({
+        where: { platform_id: rolePlatformId },
+        data: {
+          users: {
+            disconnect: { platform_id: userPlatformId },
+          },
+        },
+      });
+      return true;
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.ROLE,
+        `removeRoleFromUser | ${error.message}`,
+      );
+    }
+    return false;
   }
 
   private toPersistence(role: Partial<RoleEntity>) {

--- a/src/tests/role/repository.test.ts
+++ b/src/tests/role/repository.test.ts
@@ -1,7 +1,7 @@
 import { ILoggerService } from "@services/ILogger";
 import { PrismaService } from "@infra/persistence/prisma/prismaService";
 import { RoleRepository } from "@infra/repositories/RoleRepository";
-import { mockDBRoleValue } from "../config/constants";
+import { mockDBRoleValue, mockDBUserValue } from "../config/constants";
 import { prismaMock } from "../config/singleton";
 import { PrismaMapper } from "@infra/repositories/PrismaMapper";
 
@@ -59,16 +59,17 @@ describe("RoleRepository", () => {
         include: { users: true },
       });
 
-      expect(role).toBeUndefined();
+      expect(role).toBeNull();
     });
 
     it("should log an error", async () => {
       prismaMock.role.findUnique.mockRejectedValue(new Error());
       const spy = jest.spyOn(console, "error");
 
-      await roleRepository.findById(mockDBRoleValue.id);
+      const role = await roleRepository.findById(mockDBRoleValue.id);
 
       expect(spy).toHaveBeenCalledWith("ERROR");
+      expect(role).toBeNull();
     });
   });
 
@@ -98,7 +99,7 @@ describe("RoleRepository", () => {
       const role = await roleRepository.findByUserPlatformId(platform_id);
 
       expect(prismaMock.role.findMany).toHaveBeenCalledTimes(1);
-      expect(role).toBeUndefined();
+      expect(role).toBeNull();
     });
   });
 
@@ -134,7 +135,7 @@ describe("RoleRepository", () => {
         where: { platform_id: platform_id },
         include: { users: true },
       });
-      expect(role).toBeUndefined();
+      expect(role).toBeNull();
     });
   });
 
@@ -164,7 +165,7 @@ describe("RoleRepository", () => {
         name: "dev",
       };
 
-      prismaMock.user.update.mockRejectedValue(new Error());
+      prismaMock.role.update.mockRejectedValue(new Error());
       await roleRepository.updateById(id, roleData);
 
       expect(prismaMock.role.update).toHaveBeenCalledTimes(1);
@@ -210,7 +211,7 @@ describe("RoleRepository", () => {
         where: { id: mockDBRoleValue.id },
       });
 
-      expect(role).toBe(role);
+      expect(role).toBe(true);
     });
 
     it("should throw an error", async () => {
@@ -225,6 +226,123 @@ describe("RoleRepository", () => {
       expect(prismaMock.role.delete).toHaveBeenCalledWith({
         where: { id: mockDBRoleValue.id },
       });
+    });
+  });
+
+  describe("create", () => {
+    it("should create a role", async () => {
+      const roleInput = {
+        platformId: "new-role-id",
+        name: "new-role",
+        platformCreatedAt: new Date("2025-01-01"),
+      };
+      const createdRole = {
+        ...mockDBRoleValue,
+        platform_id: roleInput.platformId,
+        name: roleInput.name,
+        users: [],
+      };
+
+      prismaMock.role.create.mockResolvedValue(createdRole);
+
+      const role = await roleRepository.create(roleInput);
+
+      expect(prismaMock.role.create).toHaveBeenCalledTimes(1);
+      expect(prismaMock.role.create).toHaveBeenCalledWith({
+        data: {
+          platform_id: roleInput.platformId,
+          name: roleInput.name,
+          platform_created_at: roleInput.platformCreatedAt,
+        },
+      });
+      expect(role).toHaveProperty("platformId", roleInput.platformId);
+      expect(role).toHaveProperty("name", roleInput.name);
+    });
+
+    it("should throw an error on create failure", async () => {
+      const roleInput = {
+        platformId: "new-role-id",
+        name: "new-role",
+        platformCreatedAt: new Date("2025-01-01"),
+      };
+
+      prismaMock.role.create.mockRejectedValue(new Error("Create failed"));
+      const spy = jest.spyOn(console, "error");
+
+      await expect(roleRepository.create(roleInput)).rejects.toThrow(
+        "Create failed",
+      );
+      expect(spy).toHaveBeenCalledWith("ERROR");
+    });
+  });
+
+  describe("assignRoleToUser", () => {
+    it("should assign a role to a user", async () => {
+      prismaMock.role.update.mockResolvedValue(mockDBRoleValue);
+
+      const result = await roleRepository.assignRoleToUser(
+        mockDBRoleValue.platform_id,
+        mockDBUserValue.platform_id,
+      );
+
+      expect(prismaMock.role.update).toHaveBeenCalledTimes(1);
+      expect(prismaMock.role.update).toHaveBeenCalledWith({
+        where: { platform_id: mockDBRoleValue.platform_id },
+        data: {
+          users: {
+            connect: { platform_id: mockDBUserValue.platform_id },
+          },
+        },
+      });
+      expect(result).toBe(true);
+    });
+
+    it("should return false on error", async () => {
+      prismaMock.role.update.mockRejectedValue(new Error("Assign failed"));
+      const spy = jest.spyOn(console, "error");
+
+      const result = await roleRepository.assignRoleToUser(
+        mockDBRoleValue.platform_id,
+        mockDBUserValue.platform_id,
+      );
+
+      expect(spy).toHaveBeenCalledWith("ERROR");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("removeRoleFromUser", () => {
+    it("should remove a role from a user", async () => {
+      prismaMock.role.update.mockResolvedValue(mockDBRoleValue);
+
+      const result = await roleRepository.removeRoleFromUser(
+        mockDBRoleValue.platform_id,
+        mockDBUserValue.platform_id,
+      );
+
+      expect(prismaMock.role.update).toHaveBeenCalledTimes(1);
+      expect(prismaMock.role.update).toHaveBeenCalledWith({
+        where: { platform_id: mockDBRoleValue.platform_id },
+        data: {
+          users: {
+            disconnect: { platform_id: mockDBUserValue.platform_id },
+          },
+        },
+      });
+      expect(result).toBe(true);
+    });
+
+    it("should return false on error", async () => {
+      prismaMock.role.update.mockRejectedValue(new Error("Remove failed"));
+      const spy = jest.spyOn(console, "error");
+
+      const result = await roleRepository.removeRoleFromUser(
+        mockDBRoleValue.platform_id,
+        mockDBUserValue.platform_id,
+      );
+
+      expect(spy).toHaveBeenCalledWith("ERROR");
+      expect(result).toBe(false);
     });
   });
 });

--- a/src/tests/role/useCases.test.ts
+++ b/src/tests/role/useCases.test.ts
@@ -1,0 +1,247 @@
+import { mockDeep, MockProxy } from "jest-mock-extended";
+import { UpdateUserRole } from "@useCases/role/UpdateUserRole";
+import { IRoleRepository } from "@repositories/IRoleRepository";
+import { IUserRepository } from "@repositories/IUserRepository";
+import { ICreateUser } from "@interfaces/useCases/user/ICreateUser";
+import { ILoggerService } from "@services/ILogger";
+import { UserStatus } from "@type/UserStatusEnum";
+import { RoleEntity } from "@domain/entities/Role";
+import { UserEntity } from "@domain/entities/User";
+
+const mockUserEntity: UserEntity = {
+  id: 1,
+  platformId: "user-123",
+  username: "testuser",
+  globalName: "Test User",
+  bot: false,
+  status: UserStatus.ACTIVE,
+  joinedAt: new Date("2025-01-01"),
+  platformCreatedAt: new Date("2025-01-01"),
+  createAt: new Date("2025-01-01"),
+  updateAt: new Date("2025-01-01"),
+  lastActive: new Date("2025-01-01"),
+  email: null,
+};
+
+const mockRoleEntity: RoleEntity = {
+  id: 1,
+  platformId: "role-123",
+  name: "Cargo Teste",
+  createdAt: new Date("2025-01-01"),
+  platformCreatedAt: new Date("2025-01-01"),
+  user: [],
+};
+
+const mockSyncInput = {
+  userPlatformId: "user-123",
+  username: "testuser",
+  userGlobalName: "Usuario Teste",
+  userBot: false,
+  userPlatformCreatedAt: new Date("2025-01-01"),
+  userJoinedAt: new Date("2025-01-01"),
+  roles: [
+    {
+      platformId: "role-123",
+      name: "Test Role",
+      platformCreatedAt: new Date("2025-01-01"),
+    },
+    {
+      platformId: "role-456",
+      name: "Another Role",
+      platformCreatedAt: new Date("2025-01-01"),
+    },
+  ],
+};
+
+describe("UpdateUserRole", () => {
+  let roleRepository: MockProxy<IRoleRepository>;
+  let userRepository: MockProxy<IUserRepository>;
+  let createUser: MockProxy<ICreateUser>;
+  let logger: MockProxy<ILoggerService>;
+  let updateUserRole: UpdateUserRole;
+
+  beforeEach(() => {
+    roleRepository = mockDeep<IRoleRepository>();
+    userRepository = mockDeep<IUserRepository>();
+    createUser = mockDeep<ICreateUser>();
+    logger = mockDeep<ILoggerService>();
+    updateUserRole = new UpdateUserRole(
+      roleRepository,
+      userRepository,
+      createUser,
+      logger,
+    );
+  });
+
+  describe("syncUserRoles - new user", () => {
+    it("should create user and assign all roles", async () => {
+      // Usuario nao existe
+      userRepository.findByPlatformId.mockResolvedValue(null);
+      createUser.execute.mockResolvedValue({
+        success: true,
+        data: mockUserEntity,
+      });
+
+      // Cargos nao existem
+      roleRepository.findByPlatformId.mockResolvedValue(null);
+      roleRepository.create.mockResolvedValue(mockRoleEntity);
+      roleRepository.assignRoleToUser.mockResolvedValue(true);
+
+      const result = await updateUserRole.syncUserRoles(mockSyncInput);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        added: 2,
+        removed: 0,
+        total: 2,
+        isNewUser: true,
+      });
+      expect(createUser.execute).toHaveBeenCalledTimes(1);
+      expect(roleRepository.create).toHaveBeenCalledTimes(2);
+      expect(roleRepository.assignRoleToUser).toHaveBeenCalledTimes(2);
+    });
+
+    it("should create user and reuse existing roles", async () => {
+      // Usuario nao existe
+      userRepository.findByPlatformId.mockResolvedValue(null);
+      createUser.execute.mockResolvedValue({
+        success: true,
+        data: mockUserEntity,
+      });
+
+      // Primeiro cargo existe, segundo nao
+      roleRepository.findByPlatformId
+        .mockResolvedValueOnce(mockRoleEntity)
+        .mockResolvedValueOnce(null);
+      roleRepository.create.mockResolvedValue(mockRoleEntity);
+      roleRepository.assignRoleToUser.mockResolvedValue(true);
+
+      const result = await updateUserRole.syncUserRoles(mockSyncInput);
+
+      expect(result.success).toBe(true);
+      expect(result.data.isNewUser).toBe(true);
+      expect(result.data.added).toBe(2);
+      expect(roleRepository.create).toHaveBeenCalledTimes(1);
+      expect(roleRepository.assignRoleToUser).toHaveBeenCalledTimes(2);
+    });
+
+    it("should fail if user creation fails", async () => {
+      userRepository.findByPlatformId.mockResolvedValue(null);
+      createUser.execute.mockResolvedValue({
+        success: false,
+        data: null,
+        message: "User creation failed",
+      });
+
+      const result = await updateUserRole.syncUserRoles(mockSyncInput);
+
+      expect(result.success).toBe(false);
+      expect(result.data).toBeNull();
+      expect(roleRepository.assignRoleToUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("syncUserRoles - existing user", () => {
+    it("should add missing roles and remove extra roles", async () => {
+      // Usuario existe
+      userRepository.findByPlatformId.mockResolvedValue(mockUserEntity);
+
+      // Usuario tem role-999 no BD (deve ser removido)
+      const dbRole: RoleEntity = {
+        ...mockRoleEntity,
+        platformId: "role-999",
+        name: "Old Role",
+      };
+      roleRepository.findByUserPlatformId.mockResolvedValue([dbRole]);
+
+      // Novos cargos nao existem
+      roleRepository.findByPlatformId.mockResolvedValue(null);
+      roleRepository.create.mockResolvedValue(mockRoleEntity);
+      roleRepository.assignRoleToUser.mockResolvedValue(true);
+      roleRepository.removeRoleFromUser.mockResolvedValue(true);
+
+      const result = await updateUserRole.syncUserRoles(mockSyncInput);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        added: 2,
+        removed: 1,
+        total: 2,
+        isNewUser: false,
+      });
+      // Deve adicionar 2 novos cargos
+      expect(roleRepository.assignRoleToUser).toHaveBeenCalledTimes(2);
+      // Deve remover 1 cargo antigo
+      expect(roleRepository.removeRoleFromUser).toHaveBeenCalledTimes(1);
+      expect(roleRepository.removeRoleFromUser).toHaveBeenCalledWith(
+        "role-999",
+        "user-123",
+      );
+    });
+
+    it("should do nothing if roles are in sync", async () => {
+      // Usuario existe
+      userRepository.findByPlatformId.mockResolvedValue(mockUserEntity);
+
+      // Usuario ja tem os mesmos cargos
+      const dbRoles: RoleEntity[] = [
+        { ...mockRoleEntity, platformId: "role-123", name: "Test Role" },
+        { ...mockRoleEntity, platformId: "role-456", name: "Another Role" },
+      ];
+      roleRepository.findByUserPlatformId.mockResolvedValue(dbRoles);
+
+      const result = await updateUserRole.syncUserRoles(mockSyncInput);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        added: 0,
+        removed: 0,
+        total: 2,
+        isNewUser: false,
+      });
+      expect(roleRepository.assignRoleToUser).not.toHaveBeenCalled();
+      expect(roleRepository.removeRoleFromUser).not.toHaveBeenCalled();
+      expect(createUser.execute).not.toHaveBeenCalled();
+    });
+
+    it("should only add missing roles when some exist", async () => {
+      // Usuario existe
+      userRepository.findByPlatformId.mockResolvedValue(mockUserEntity);
+
+      // Usuario tem um dos cargos
+      const dbRoles: RoleEntity[] = [
+        { ...mockRoleEntity, platformId: "role-123", name: "Test Role" },
+      ];
+      roleRepository.findByUserPlatformId.mockResolvedValue(dbRoles);
+
+      // Segundo cargo nao existe
+      roleRepository.findByPlatformId.mockResolvedValue(null);
+      roleRepository.create.mockResolvedValue(mockRoleEntity);
+      roleRepository.assignRoleToUser.mockResolvedValue(true);
+
+      const result = await updateUserRole.syncUserRoles(mockSyncInput);
+
+      expect(result.success).toBe(true);
+      expect(result.data.added).toBe(1);
+      expect(result.data.removed).toBe(0);
+      expect(result.data.isNewUser).toBe(false);
+      // Deve adicionar apenas 1 cargo faltante
+      expect(roleRepository.assignRoleToUser).toHaveBeenCalledTimes(1);
+      expect(roleRepository.removeRoleFromUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("syncUserRoles - error handling", () => {
+    it("should return error on repository failure", async () => {
+      userRepository.findByPlatformId.mockRejectedValue(
+        new Error("Database error"),
+      );
+
+      const result = await updateUserRole.syncUserRoles(mockSyncInput);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Database error");
+      expect(logger.logToConsole).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Descrição

Adiciona suporte ao armazenamento de cargos dos usuários.
Quando há evento de atualização de informação do usuário, fazemos um diff dos cargos armazenados no BD e dos cargos atualizados. Fazemos a remoção de cargos não mais relacionados ao usuário e salvamos cargos do usuário que não temos no BD.

Desta maneira, conseguimos garantir consistência eventual. Sempre que houver atualiazação do usuário, sincronizamos todos os cargos. 

## Link da tarefa

CPDD-130

## Tipo de mudança

- [ ] Bugfix
- [X] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

## Como foi testado?
### Usuário sem cargos
1. Cargo salvo no banco
2. Cargo associado ao usuário

### Usuário com cargo
1. Cargo removido do usuário

### Usuário com um cargo não salvo
1. Novo cargo salvo no BD
2. Novo cargo associado ao usuário
3. Cargo antigo (mas não no banco) associado ao usuário
4. BD tem os dois cargos salvos.

## Checklist

- [X] Código segue o padrão de estilo do projeto
- [X] Testes unitários foram adicionados
- [ ] A documentação foi atualizada (se aplicável)
