### PR TITLE
CPDD-29 - useCases - MessageReaction - Registrar evento do discord de reação a uma mensagem

### DIFF
--- a/src/application/command/messageReactionCommand.ts
+++ b/src/application/command/messageReactionCommand.ts
@@ -1,0 +1,156 @@
+import {
+  MessageReaction,
+  PartialMessageReaction,
+  PartialUser,
+  User,
+} from "discord.js";
+import { IDiscordService } from "@services/IDiscordService";
+import { ILoggerService } from "@services/ILogger";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "@type/LoggerContextEnum";
+import { IRegisterMessageReaction } from "@interfaces/useCases/messageReaction/IRegisterMessageReaction";
+import { RegisterMessageReactionInput } from "@interfaces/useCases/messageReaction/IRegisterMessageReaction";
+import { Client } from "discord.js";
+
+export class MessageReactionCommand {
+  constructor(
+    private readonly discordService: IDiscordService<
+      unknown,
+      unknown,
+      unknown,
+      Client,
+      unknown,
+      unknown,
+      unknown,
+      MessageReaction | PartialMessageReaction,
+      User | PartialUser
+    >,
+    private readonly logger: ILoggerService,
+    private readonly registerMessageReaction: IRegisterMessageReaction,
+  ) {
+    this.executeReactionHandler();
+  }
+
+  private executeReactionHandler(): void {
+    try {
+      this.discordService.onReactionAdd(this.handleReaction.bind(this));
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `executeReactionHandler | ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  private async handleReaction(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
+  ): Promise<void> {
+    try {
+      if (user.bot) {
+        return;
+      }
+
+      if (reaction.partial) {
+        await reaction.fetch();
+      }
+      if (reaction.message.partial) {
+        await reaction.message.fetch();
+      }
+
+      const input = MessageReactionCommand.toRegisterMessageReactionInput(
+        reaction,
+        user,
+      );
+
+      const result = await this.registerMessageReaction.execute(input);
+
+      const emojiLabel =
+        reaction.emoji.name ??
+        reaction.emoji.id ??
+        reaction.emoji.identifier ??
+        "";
+      const logPayload = `user_id=${input.userId} message_id=${input.messageId} reaction=${emojiLabel}`;
+
+      if (result.success) {
+        this.logger.logToConsole(
+          LoggerContextStatus.SUCCESS,
+          LoggerContext.COMMAND,
+          LoggerContextEntity.MESSAGE_REACTION,
+          `Reaction registered: ${logPayload}`,
+        );
+      } else {
+        this.logger.logToConsole(
+          LoggerContextStatus.ERROR,
+          LoggerContext.COMMAND,
+          LoggerContextEntity.MESSAGE_REACTION,
+          `Failed to register reaction (${logPayload}): ${result.message ?? "Unknown error"}`,
+        );
+      }
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `handleReaction | ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  static toRegisterMessageReactionInput(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
+  ): RegisterMessageReactionInput {
+    const message = reaction.message;
+    const channel = message.channel;
+    const emoji =
+      reaction.emoji.identifier ??
+      reaction.emoji.name ??
+      reaction.emoji.id ??
+      "";
+
+    let channelName = "Unknown Channel";
+    let channelUrl = "";
+
+    if (channel && "name" in channel && channel.name) {
+      channelName = channel.name;
+    }
+    if (channel && "url" in channel && channel.url) {
+      channelUrl = channel.url;
+    } else if (message.guild && channel && "id" in channel) {
+      channelUrl = `https://discord.com/channels/${message.guild.id}/${channel.id}`;
+    }
+
+    let userJoinedAt: Date | null = null;
+    const member = message.guild?.members.resolve(user.id);
+    if (member?.joinedAt) {
+      userJoinedAt = member.joinedAt;
+    }
+
+    return {
+      userId: user.id,
+      messageId: message.id,
+      channelId: channel.id,
+      reactionEmoji: emoji,
+      reactedAt: new Date(),
+      username: "username" in user ? user.username : undefined,
+      userGlobalName: "globalName" in user ? user.globalName : undefined,
+      userBot: "bot" in user ? user.bot : undefined,
+      userPlatformCreatedAt:
+        "createdTimestamp" in user && user.createdTimestamp
+          ? new Date(user.createdTimestamp)
+          : undefined,
+      userJoinedAt,
+      channelName,
+      channelUrl,
+      messagePlatformCreatedAt: message.createdTimestamp
+        ? new Date(message.createdTimestamp)
+        : undefined,
+    };
+  }
+}

--- a/src/application/command/messageReactionCommand.ts
+++ b/src/application/command/messageReactionCommand.ts
@@ -13,6 +13,10 @@ import {
 } from "@type/LoggerContextEnum";
 import { IRegisterMessageReaction } from "@interfaces/useCases/messageReaction/IRegisterMessageReaction";
 import { RegisterMessageReactionInput } from "@interfaces/useCases/messageReaction/IRegisterMessageReaction";
+import {
+  IRemoveMessageReaction,
+  RemoveMessageReactionInput,
+} from "@interfaces/useCases/messageReaction/IRemoveMessageReaction";
 import { Client } from "discord.js";
 
 export class MessageReactionCommand {
@@ -30,6 +34,7 @@ export class MessageReactionCommand {
     >,
     private readonly logger: ILoggerService,
     private readonly registerMessageReaction: IRegisterMessageReaction,
+    private readonly removeMessageReaction: IRemoveMessageReaction,
   ) {
     this.executeReactionHandler();
   }
@@ -37,6 +42,9 @@ export class MessageReactionCommand {
   private executeReactionHandler(): void {
     try {
       this.discordService.onReactionAdd(this.handleReaction.bind(this));
+      this.discordService.onReactionRemove(
+        this.handleReactionRemove.bind(this),
+      );
     } catch (error) {
       this.logger.logToConsole(
         LoggerContextStatus.ERROR,
@@ -98,6 +106,57 @@ export class MessageReactionCommand {
     }
   }
 
+  private async handleReactionRemove(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
+  ): Promise<void> {
+    try {
+      if (user?.bot) {
+        return;
+      }
+
+      if (reaction.partial) {
+        await reaction.fetch();
+      }
+      if (reaction.message.partial) {
+        await reaction.message.fetch();
+      }
+
+      const input = MessageReactionCommand.toRemoveMessageReactionInput(
+        reaction,
+        user,
+      );
+
+      const result = await this.removeMessageReaction.execute(input);
+
+      const emojiLabel = MessageReactionCommand.getEmojiFromReaction(reaction);
+      const logPayload = `user_id=${input.userId} message_id=${input.messageId} reaction=${emojiLabel}`;
+
+      if (result.success) {
+        this.logger.logToConsole(
+          LoggerContextStatus.SUCCESS,
+          LoggerContext.COMMAND,
+          LoggerContextEntity.MESSAGE_REACTION,
+          `Reaction removed: ${logPayload}`,
+        );
+      } else {
+        this.logger.logToConsole(
+          LoggerContextStatus.ERROR,
+          LoggerContext.COMMAND,
+          LoggerContextEntity.MESSAGE_REACTION,
+          `Failed to remove reaction (${logPayload}): ${result.message ?? "Unknown error"}`,
+        );
+      }
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.COMMAND,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `handleReactionRemove | ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
   /**
    * Resolve o identificador do emoji a partir do payload de reação (unicode, custom id ou nome).
    */
@@ -110,6 +169,20 @@ export class MessageReactionCommand {
       reaction.emoji.id ??
       ""
     );
+  }
+
+  static toRemoveMessageReactionInput(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
+  ): RemoveMessageReactionInput {
+    const message = reaction.message;
+    const emoji = MessageReactionCommand.getEmojiFromReaction(reaction);
+
+    return {
+      userId: user.id,
+      messageId: message.id,
+      reactionEmoji: emoji,
+    };
   }
 
   static toRegisterMessageReactionInput(

--- a/src/application/command/messageReactionCommand.ts
+++ b/src/application/command/messageReactionCommand.ts
@@ -52,7 +52,7 @@ export class MessageReactionCommand {
     user: User | PartialUser,
   ): Promise<void> {
     try {
-      if (user.bot) {
+      if (user?.bot) {
         return;
       }
 
@@ -70,11 +70,7 @@ export class MessageReactionCommand {
 
       const result = await this.registerMessageReaction.execute(input);
 
-      const emojiLabel =
-        reaction.emoji.name ??
-        reaction.emoji.id ??
-        reaction.emoji.identifier ??
-        "";
+      const emojiLabel = MessageReactionCommand.getEmojiFromReaction(reaction);
       const logPayload = `user_id=${input.userId} message_id=${input.messageId} reaction=${emojiLabel}`;
 
       if (result.success) {
@@ -102,17 +98,27 @@ export class MessageReactionCommand {
     }
   }
 
+  /**
+   * Resolve o identificador do emoji a partir do payload de reação (unicode, custom id ou nome).
+   */
+  static getEmojiFromReaction(
+    reaction: MessageReaction | PartialMessageReaction,
+  ): string {
+    return (
+      reaction.emoji.identifier ??
+      reaction.emoji.name ??
+      reaction.emoji.id ??
+      ""
+    );
+  }
+
   static toRegisterMessageReactionInput(
     reaction: MessageReaction | PartialMessageReaction,
     user: User | PartialUser,
   ): RegisterMessageReactionInput {
     const message = reaction.message;
     const channel = message.channel;
-    const emoji =
-      reaction.emoji.identifier ??
-      reaction.emoji.name ??
-      reaction.emoji.id ??
-      "";
+    const emoji = MessageReactionCommand.getEmojiFromReaction(reaction);
 
     let channelName = "Unknown Channel";
     let channelUrl = "";
@@ -138,13 +144,12 @@ export class MessageReactionCommand {
       channelId: channel.id,
       reactionEmoji: emoji,
       reactedAt: new Date(),
-      username: "username" in user ? user.username : undefined,
-      userGlobalName: "globalName" in user ? user.globalName : undefined,
-      userBot: "bot" in user ? user.bot : undefined,
-      userPlatformCreatedAt:
-        "createdTimestamp" in user && user.createdTimestamp
-          ? new Date(user.createdTimestamp)
-          : undefined,
+      username: user?.username,
+      userGlobalName: user?.globalName,
+      userBot: user?.bot,
+      userPlatformCreatedAt: user?.createdTimestamp
+        ? new Date(user.createdTimestamp)
+        : undefined,
       userJoinedAt,
       channelName,
       channelUrl,

--- a/src/contexts/app.context.ts
+++ b/src/contexts/app.context.ts
@@ -68,14 +68,15 @@ export function initializeApp() {
     logger,
   );
 
-  const { registerMessageReaction } = initializeMessageReactionUseCases(
-    messageReactionRepository,
-    userRepository,
-    channelRepository,
-    messageRepository,
-    userUseCases.createUserCase,
-    logger,
-  );
+  const { registerMessageReaction, removeMessageReaction } =
+    initializeMessageReactionUseCases(
+      messageReactionRepository,
+      userRepository,
+      channelRepository,
+      messageRepository,
+      userUseCases.createUserCase,
+      logger,
+    );
 
   // E finalmente as inicializacoes da aplicacao
   new UserCommand(
@@ -98,7 +99,12 @@ export function initializeApp() {
   );
 
   new MessageCommand(discordService, logger, registerMessage);
-  new MessageReactionCommand(discordService, logger, registerMessageReaction);
+  new MessageReactionCommand(
+    discordService,
+    logger,
+    registerMessageReaction,
+    removeMessageReaction,
+  );
 
   // Isso deve ser executado depois que o user command for iniciado
   discordService.registerEvents();

--- a/src/contexts/app.context.ts
+++ b/src/contexts/app.context.ts
@@ -1,5 +1,6 @@
 import { ChannelCommand } from "@application/command/channelCommand";
 import { MessageCommand } from "@application/command/messageCommand";
+import { MessageReactionCommand } from "@application/command/messageReactionCommand";
 import { UserCommand } from "@application/command/userCommand";
 import { VoiceEventCommand } from "@application/command/voiceEventCommand";
 import { Logger } from "@application/services/Logger";
@@ -13,6 +14,7 @@ import { initializeDatabase } from "./database.context";
 import { initializeDiscord } from "./discord.context";
 import { initializeChannelUseCases } from "./useChannelCases.context";
 import { initializeMessageUseCases } from "./useMessageCases.context";
+import { initializeMessageReactionUseCases } from "./useMessageReactionCases.context";
 import { initializeUserUseCases } from "./useUserCases.context";
 import { initializeVoiceEventUseCases } from "./useVoiceEventCases.context";
 import { initializeUserEventUseCases } from "@contexts/userEventUseCases.context";
@@ -26,6 +28,7 @@ export function initializeApp() {
     userEventRepository,
     audioEventRepository,
     messageRepository,
+    messageReactionRepository,
     channelRepository,
   } = initializeDatabase(logger);
   const { discordService } = initializeDiscord();
@@ -65,6 +68,15 @@ export function initializeApp() {
     logger,
   );
 
+  const { registerMessageReaction } = initializeMessageReactionUseCases(
+    messageReactionRepository,
+    userRepository,
+    channelRepository,
+    messageRepository,
+    userUseCases.createUserCase,
+    logger,
+  );
+
   // E finalmente as inicializacoes da aplicacao
   new UserCommand(
     discordService,
@@ -86,6 +98,7 @@ export function initializeApp() {
   );
 
   new MessageCommand(discordService, logger, registerMessage);
+  new MessageReactionCommand(discordService, logger, registerMessageReaction);
 
   // Isso deve ser executado depois que o user command for iniciado
   discordService.registerEvents();

--- a/src/contexts/discord.context.ts
+++ b/src/contexts/discord.context.ts
@@ -10,6 +10,7 @@ import {
   PartialMessageReaction,
   PartialGuildMember,
   PartialUser,
+  Partials,
   User,
   VoiceState,
   PartialGuildScheduledEvent,
@@ -66,7 +67,15 @@ export function initializeDiscord(): {
   >;
 } {
   const intents = Object.values(EVENT_INTENTS_MAP).flat();
-  const client = new Client({ intents: intents });
+  const client = new Client({
+    intents,
+    partials: [
+      Partials.Message,
+      Partials.Channel,
+      Partials.Reaction,
+      Partials.User,
+    ],
+  });
   const discordService = new DiscordService(client);
   return { discordService };
 }

--- a/src/contexts/discord.context.ts
+++ b/src/contexts/discord.context.ts
@@ -6,7 +6,11 @@ import {
   GuildMember,
   GuildScheduledEvent,
   Message,
+  MessageReaction,
+  PartialMessageReaction,
   PartialGuildMember,
+  PartialUser,
+  User,
   VoiceState,
   PartialGuildScheduledEvent,
 } from "discord.js";
@@ -34,6 +38,7 @@ const EVENT_INTENTS_MAP: Partial<Record<Events, GatewayIntentBits[]>> = {
     GatewayIntentBits.GuildScheduledEvents,
   ],
   [Events.VoiceStateUpdate]: [GatewayIntentBits.GuildVoiceStates],
+  [Events.MessageReactionAdd]: [GatewayIntentBits.GuildMessageReactions],
 };
 
 /**
@@ -55,7 +60,9 @@ export function initializeDiscord(): {
     Client,
     VoiceState,
     GuildChannel,
-    GuildScheduledEvent | PartialGuildScheduledEvent
+    GuildScheduledEvent | PartialGuildScheduledEvent,
+    MessageReaction | PartialMessageReaction,
+    User | PartialUser
   >;
 } {
   const intents = Object.values(EVENT_INTENTS_MAP).flat();

--- a/src/contexts/useMessageReactionCases.context.ts
+++ b/src/contexts/useMessageReactionCases.context.ts
@@ -1,0 +1,29 @@
+import { IMessageReactionRepository } from "@repositories/IMessageReactionRepository";
+import { IUserRepository } from "@repositories/IUserRepository";
+import { IChannelRepository } from "@repositories/IChannelRepository";
+import { IMessageRepository } from "@repositories/IMessageRepository";
+import { ICreateUser } from "@interfaces/useCases/user/ICreateUser";
+import { ILoggerService } from "@services/ILogger";
+import { RegisterMessageReaction } from "@domain/useCases/messageReaction/RegisterMessageReaction";
+
+export function initializeMessageReactionUseCases(
+  messageReactionRepository: IMessageReactionRepository,
+  userRepository: IUserRepository,
+  channelRepository: IChannelRepository,
+  messageRepository: IMessageRepository,
+  createUser: ICreateUser,
+  logger: ILoggerService,
+): {
+  registerMessageReaction: RegisterMessageReaction;
+} {
+  const registerMessageReaction = new RegisterMessageReaction(
+    messageReactionRepository,
+    userRepository,
+    channelRepository,
+    messageRepository,
+    createUser,
+    logger,
+  );
+
+  return { registerMessageReaction };
+}

--- a/src/contexts/useMessageReactionCases.context.ts
+++ b/src/contexts/useMessageReactionCases.context.ts
@@ -5,6 +5,7 @@ import { IMessageRepository } from "@repositories/IMessageRepository";
 import { ICreateUser } from "@interfaces/useCases/user/ICreateUser";
 import { ILoggerService } from "@services/ILogger";
 import { RegisterMessageReaction } from "@domain/useCases/messageReaction/RegisterMessageReaction";
+import { RemoveMessageReaction } from "@domain/useCases/messageReaction/RemoveMessageReaction";
 
 export function initializeMessageReactionUseCases(
   messageReactionRepository: IMessageReactionRepository,
@@ -15,6 +16,7 @@ export function initializeMessageReactionUseCases(
   logger: ILoggerService,
 ): {
   registerMessageReaction: RegisterMessageReaction;
+  removeMessageReaction: RemoveMessageReaction;
 } {
   const registerMessageReaction = new RegisterMessageReaction(
     messageReactionRepository,
@@ -25,5 +27,10 @@ export function initializeMessageReactionUseCases(
     logger,
   );
 
-  return { registerMessageReaction };
+  const removeMessageReaction = new RemoveMessageReaction(
+    messageReactionRepository,
+    logger,
+  );
+
+  return { registerMessageReaction, removeMessageReaction };
 }

--- a/src/domain/dtos/CreateMessageReactionData.ts
+++ b/src/domain/dtos/CreateMessageReactionData.ts
@@ -2,4 +2,6 @@ export type CreateMessageReactionData = {
   userId: string;
   messageId: string;
   channelId: string;
+  reactionEmoji?: string;
+  reactedAt?: Date;
 };

--- a/src/domain/entities/MessageReaction.ts
+++ b/src/domain/entities/MessageReaction.ts
@@ -8,5 +8,7 @@ export class MessageReactionEntity {
     public readonly user?: UserEntity,
     public readonly message?: MessageEntity,
     public readonly channel?: ChannelEntity,
+    public readonly reactionEmoji?: string,
+    public readonly reactedAt?: Date,
   ) {}
 }

--- a/src/domain/interfaces/repositories/IMessageReactionRepository.ts
+++ b/src/domain/interfaces/repositories/IMessageReactionRepository.ts
@@ -18,6 +18,12 @@ export interface IMessageReactionRepository {
     userPlatformId: string,
   ): Promise<MessageReactionEntity[]>;
 
+  findByUserMessageAndEmoji(
+    userId: string,
+    messageId: string,
+    reactionEmoji: string,
+  ): Promise<MessageReactionEntity | null>;
+
   updateMessageReaction(
     id: number,
     data: UpdateMessageReactionData,

--- a/src/domain/interfaces/services/IDiscordService.ts
+++ b/src/domain/interfaces/services/IDiscordService.ts
@@ -17,6 +17,7 @@ export interface IDiscordService<
   onVoiceEventUserChange(handler: (oldState: S, newState: S) => void): void;
   onVoiceEvent(handler: (event: E) => void): void;
   onReactionAdd(handler: (reaction: R, user: U2) => void): void;
+  onReactionRemove(handler: (reaction: R, user: U2) => void): void;
   registerEvents(): void;
   onCreateChannel(handler: (channel: C) => void): void;
   onChangeChannel(handler: (oldChannel: C, newChannel: C) => void): void;

--- a/src/domain/interfaces/services/IDiscordService.ts
+++ b/src/domain/interfaces/services/IDiscordService.ts
@@ -6,6 +6,8 @@ export interface IDiscordService<
   S = unknown,
   C = unknown,
   E = unknown,
+  R = unknown,
+  U2 = unknown,
 > {
   client: T;
   onDiscordStart(handler: () => void): void;
@@ -14,6 +16,7 @@ export interface IDiscordService<
   onUserLeave(handler: (member: U | P) => void): void;
   onVoiceEventUserChange(handler: (oldState: S, newState: S) => void): void;
   onVoiceEvent(handler: (event: E) => void): void;
+  onReactionAdd(handler: (reaction: R, user: U2) => void): void;
   registerEvents(): void;
   onCreateChannel(handler: (channel: C) => void): void;
   onChangeChannel(handler: (oldChannel: C, newChannel: C) => void): void;

--- a/src/domain/interfaces/useCases/messageReaction/IRegisterMessageReaction.ts
+++ b/src/domain/interfaces/useCases/messageReaction/IRegisterMessageReaction.ts
@@ -1,0 +1,24 @@
+import { MessageReactionEntity } from "@entities/MessageReaction";
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+
+export interface RegisterMessageReactionInput {
+  userId: string;
+  messageId: string;
+  channelId: string;
+  reactionEmoji?: string;
+  reactedAt?: Date;
+  username?: string;
+  userGlobalName?: string | null;
+  userBot?: boolean;
+  userPlatformCreatedAt?: Date;
+  userJoinedAt?: Date | null;
+  channelName?: string;
+  channelUrl?: string;
+  messagePlatformCreatedAt?: Date;
+}
+
+export interface IRegisterMessageReaction {
+  execute(
+    input: RegisterMessageReactionInput,
+  ): Promise<GenericOutputDto<MessageReactionEntity>>;
+}

--- a/src/domain/interfaces/useCases/messageReaction/IRemoveMessageReaction.ts
+++ b/src/domain/interfaces/useCases/messageReaction/IRemoveMessageReaction.ts
@@ -1,0 +1,13 @@
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+
+export interface RemoveMessageReactionInput {
+  userId: string;
+  messageId: string;
+  reactionEmoji?: string;
+}
+
+export interface IRemoveMessageReaction {
+  execute(
+    input: RemoveMessageReactionInput,
+  ): Promise<GenericOutputDto<boolean>>;
+}

--- a/src/domain/useCases/messageReaction/RegisterMessageReaction.ts
+++ b/src/domain/useCases/messageReaction/RegisterMessageReaction.ts
@@ -1,0 +1,182 @@
+import { MessageReactionEntity } from "@entities/MessageReaction";
+import { ChannelEntity } from "@entities/Channel";
+import { IMessageReactionRepository } from "@repositories/IMessageReactionRepository";
+import { IUserRepository } from "@repositories/IUserRepository";
+import { IChannelRepository } from "@repositories/IChannelRepository";
+import { IMessageRepository } from "@repositories/IMessageRepository";
+import { ICreateUser } from "@interfaces/useCases/user/ICreateUser";
+import { ILoggerService } from "@services/ILogger";
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+import { ErrorMessages } from "@type/ErrorMessages";
+import {
+  LoggerContextStatus,
+  LoggerContext,
+  LoggerContextEntity,
+} from "@type/LoggerContextEnum";
+import {
+  RegisterMessageReactionInput,
+  IRegisterMessageReaction,
+} from "@interfaces/useCases/messageReaction/IRegisterMessageReaction";
+import { UserStatus } from "@type/UserStatusEnum";
+
+export class RegisterMessageReaction implements IRegisterMessageReaction {
+  constructor(
+    private readonly messageReactionRepository: IMessageReactionRepository,
+    private readonly userRepository: IUserRepository,
+    private readonly channelRepository: IChannelRepository,
+    private readonly messageRepository: IMessageRepository,
+    private readonly createUser: ICreateUser,
+    private readonly logger: ILoggerService,
+  ) {}
+
+  async execute(
+    input: RegisterMessageReactionInput,
+  ): Promise<GenericOutputDto<MessageReactionEntity>> {
+    try {
+      let user = await this.userRepository.findByPlatformId(input.userId, true);
+
+      if (!user) {
+        if (!input.username) {
+          return {
+            data: null,
+            success: false,
+            message: "User data required for user creation",
+          };
+        }
+
+        const createUserResult = await this.createUser.execute({
+          platformId: input.userId,
+          username: input.username,
+          globalName: input.userGlobalName ?? null,
+          bot: input.userBot ?? false,
+          status: UserStatus.ACTIVE,
+          platformCreatedAt: input.userPlatformCreatedAt,
+          joinedAt: input.userJoinedAt ?? null,
+          lastActive: undefined,
+        });
+
+        if (!createUserResult.success || !createUserResult.data) {
+          return {
+            data: null,
+            success: false,
+            message: createUserResult.message || ErrorMessages.UNKNOWN_ERROR,
+          };
+        }
+        user = createUserResult.data;
+      }
+
+      let channel = await this.channelRepository.findByPlatformId(
+        input.channelId,
+      );
+
+      if (!channel) {
+        const channelName = input.channelName ?? "Unknown Channel";
+        const channelUrl = input.channelUrl ?? "";
+
+        const channelData: Omit<ChannelEntity, "id"> = {
+          platformId: input.channelId,
+          name: channelName,
+          url: channelUrl,
+          createdAt: new Date(),
+        };
+
+        const newChannel = await this.channelRepository.create(channelData);
+        if (!newChannel) {
+          return {
+            data: null,
+            success: false,
+            message: "Failed to create channel",
+          };
+        }
+        channel = newChannel;
+      }
+
+      const message = await this.messageRepository
+        .findByPlatformId(input.messageId)
+        .catch(() => null);
+
+      if (!message) {
+        const messageData = {
+          platformId: input.messageId,
+          platformCreatedAt: input.messagePlatformCreatedAt ?? new Date(),
+          isDeleted: false,
+          channel,
+          user,
+          messageReactions: [],
+        };
+
+        const newMessage = await this.messageRepository.create(messageData);
+        if (!newMessage) {
+          return {
+            data: null,
+            success: false,
+            message: "Failed to create message",
+          };
+        }
+      }
+
+      const reactionEmoji = input.reactionEmoji ?? "";
+      const existingReaction =
+        await this.messageReactionRepository.findByUserMessageAndEmoji(
+          input.userId,
+          input.messageId,
+          reactionEmoji,
+        );
+
+      if (existingReaction) {
+        this.logger.logToConsole(
+          LoggerContextStatus.SUCCESS,
+          LoggerContext.USECASE,
+          LoggerContextEntity.MESSAGE_REACTION,
+          `Reaction registered: user=${input.userId} message=${input.messageId} emoji=${reactionEmoji || "(none)"}`,
+        );
+        return {
+          data: existingReaction,
+          success: true,
+          message: "Reaction registered",
+        };
+      }
+
+      const created = await this.messageReactionRepository.create({
+        userId: input.userId,
+        messageId: input.messageId,
+        channelId: input.channelId,
+        reactionEmoji: input.reactionEmoji,
+        reactedAt: input.reactedAt,
+      });
+
+      if (!created) {
+        return {
+          data: null,
+          success: false,
+          message: ErrorMessages.UNKNOWN_ERROR,
+        };
+      }
+
+      this.logger.logToConsole(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `Reaction registered: user=${input.userId} message=${input.messageId} emoji=${reactionEmoji || "(none)"}`,
+      );
+
+      return {
+        data: created,
+        success: true,
+      };
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.USECASE,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `registerMessageReaction.execute | ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return {
+        data: null,
+        success: false,
+        message:
+          error instanceof Error ? error.message : ErrorMessages.UNKNOWN_ERROR,
+      };
+    }
+  }
+}

--- a/src/domain/useCases/messageReaction/RemoveMessageReaction.ts
+++ b/src/domain/useCases/messageReaction/RemoveMessageReaction.ts
@@ -1,0 +1,84 @@
+import { IMessageReactionRepository } from "@repositories/IMessageReactionRepository";
+import { ILoggerService } from "@services/ILogger";
+import { GenericOutputDto } from "@dtos/GenericOutputDto";
+import { ErrorMessages } from "@type/ErrorMessages";
+import {
+  LoggerContextStatus,
+  LoggerContext,
+  LoggerContextEntity,
+} from "@type/LoggerContextEnum";
+import {
+  RemoveMessageReactionInput,
+  IRemoveMessageReaction,
+} from "@interfaces/useCases/messageReaction/IRemoveMessageReaction";
+
+export class RemoveMessageReaction implements IRemoveMessageReaction {
+  constructor(
+    private readonly messageReactionRepository: IMessageReactionRepository,
+    private readonly logger: ILoggerService,
+  ) {}
+
+  async execute(
+    input: RemoveMessageReactionInput,
+  ): Promise<GenericOutputDto<boolean>> {
+    try {
+      const reactionEmoji = input.reactionEmoji ?? "";
+      const existing =
+        await this.messageReactionRepository.findByUserMessageAndEmoji(
+          input.userId,
+          input.messageId,
+          reactionEmoji,
+        );
+
+      if (!existing) {
+        this.logger.logToConsole(
+          LoggerContextStatus.SUCCESS,
+          LoggerContext.USECASE,
+          LoggerContextEntity.MESSAGE_REACTION,
+          `Reaction not in database: user=${input.userId} message=${input.messageId} emoji=${reactionEmoji || "(none)"}`,
+        );
+        return {
+          data: false,
+          success: true,
+          message: "Reaction not in database",
+        };
+      }
+
+      const deleted =
+        await this.messageReactionRepository.deleteMessageReaction(existing.id);
+
+      if (!deleted) {
+        return {
+          data: false,
+          success: false,
+          message: ErrorMessages.UNKNOWN_ERROR,
+        };
+      }
+
+      this.logger.logToConsole(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `Reaction removed from database: user=${input.userId} message=${input.messageId} emoji=${reactionEmoji || "(none)"}`,
+      );
+
+      return {
+        data: true,
+        success: true,
+      };
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.USECASE,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `removeMessageReaction.execute | ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return {
+        data: false,
+        success: false,
+        message:
+          error instanceof Error ? error.message : ErrorMessages.UNKNOWN_ERROR,
+      };
+    }
+  }
+}

--- a/src/infrastructure/discord/DiscordService.ts
+++ b/src/infrastructure/discord/DiscordService.ts
@@ -53,6 +53,10 @@ export class DiscordService
     reaction: MessageReaction | PartialMessageReaction,
     user: User | PartialUser,
   ) => void)[] = [];
+  private onReactionRemoveHandlers: ((
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
+  ) => void)[] = [];
 
   constructor(client: Client) {
     this.client = client;
@@ -114,6 +118,10 @@ export class DiscordService
     this.client.on(Events.MessageReactionAdd, (reaction, user) => {
       this.onReactionAddHandlers.forEach((fn) => fn(reaction, user));
     });
+
+    this.client.on(Events.MessageReactionRemove, (reaction, user) => {
+      this.onReactionRemoveHandlers.forEach((fn) => fn(reaction, user));
+    });
   }
 
   public onReactionAdd(
@@ -123,6 +131,15 @@ export class DiscordService
     ) => void,
   ): void {
     this.onReactionAddHandlers.push(handler);
+  }
+
+  public onReactionRemove(
+    handler: (
+      reaction: MessageReaction | PartialMessageReaction,
+      user: User | PartialUser,
+    ) => void,
+  ): void {
+    this.onReactionRemoveHandlers.push(handler);
   }
 
   public onDiscordStart(handler: () => void): void {

--- a/src/infrastructure/discord/DiscordService.ts
+++ b/src/infrastructure/discord/DiscordService.ts
@@ -5,9 +5,13 @@ import {
   GuildChannel,
   GuildMember,
   Message,
+  MessageReaction,
+  PartialMessageReaction,
   PartialGuildMember,
+  PartialUser,
   GuildScheduledEvent,
   PartialGuildScheduledEvent,
+  User,
   VoiceState,
 } from "discord.js";
 
@@ -20,7 +24,9 @@ export class DiscordService
       Client,
       VoiceState,
       GuildChannel,
-      GuildScheduledEvent | PartialGuildScheduledEvent
+      GuildScheduledEvent | PartialGuildScheduledEvent,
+      MessageReaction | PartialMessageReaction,
+      User | PartialUser
     >
 {
   public readonly client: Client;
@@ -42,6 +48,10 @@ export class DiscordService
   private onVoiceEventUserChangeHandlers: ((
     oldState: VoiceState,
     newState: VoiceState,
+  ) => void)[] = [];
+  private onReactionAddHandlers: ((
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
   ) => void)[] = [];
 
   constructor(client: Client) {
@@ -100,6 +110,19 @@ export class DiscordService
         fn(oldState, newState),
       );
     });
+
+    this.client.on(Events.MessageReactionAdd, (reaction, user) => {
+      this.onReactionAddHandlers.forEach((fn) => fn(reaction, user));
+    });
+  }
+
+  public onReactionAdd(
+    handler: (
+      reaction: MessageReaction | PartialMessageReaction,
+      user: User | PartialUser,
+    ) => void,
+  ): void {
+    this.onReactionAddHandlers.push(handler);
   }
 
   public onDiscordStart(handler: () => void): void {

--- a/src/infrastructure/persistence/prisma/models/dbml/schema.dbml
+++ b/src/infrastructure/persistence/prisma/models/dbml/schema.dbml
@@ -99,12 +99,14 @@ Table message_reaction {
   message_id String [not null]
   channel_id String [not null]
   id Int [pk, increment]
+  reaction_emoji String [default: '']
+  reacted_at DateTime [default: `now()`, not null]
   channel channel [not null]
   message message [not null]
   user user [not null]
 
   indexes {
-    (user_id, message_id) [unique]
+    (user_id, message_id, reaction_emoji) [unique]
   }
 }
 

--- a/src/infrastructure/persistence/prisma/models/migrations/20260322180000_message_reaction_emoji_reacted_at/migration.sql
+++ b/src/infrastructure/persistence/prisma/models/migrations/20260322180000_message_reaction_emoji_reacted_at/migration.sql
@@ -1,0 +1,15 @@
+-- Drop Foreign Key
+ALTER TABLE `message_reaction` DROP FOREIGN KEY `message_reaction_user_id_fkey`;
+
+-- Drop Index
+DROP INDEX `message_reaction_user_id_message_id_key` ON `message_reaction`;
+
+-- Alter Table
+ALTER TABLE `message_reaction` ADD COLUMN `reacted_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    ADD COLUMN `reaction_emoji` VARCHAR(191) NULL DEFAULT '';
+
+-- Create Index
+CREATE UNIQUE INDEX `message_reaction_user_id_message_id_reaction_emoji_key` ON `message_reaction`(`user_id`, `message_id`, `reaction_emoji`);
+
+-- Add ForeignKey
+ALTER TABLE `message_reaction` ADD CONSTRAINT `message_reaction_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `user`(`platform_id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/infrastructure/persistence/prisma/models/schema.prisma
+++ b/src/infrastructure/persistence/prisma/models/schema.prisma
@@ -130,15 +130,17 @@ model Channel {
 }
 
 model MessageReaction {
-  user_id    String
-  message_id String
-  channel_id String
-  id         Int     @id @default(autoincrement())
-  channel    Channel @relation(fields: [channel_id], references: [platform_id])
-  message    Message @relation(fields: [message_id], references: [platform_id])
-  user       User    @relation(fields: [user_id], references: [platform_id])
+  user_id        String
+  message_id     String
+  channel_id     String
+  id             Int      @id @default(autoincrement())
+  reaction_emoji String?  @default("")
+  reacted_at     DateTime @default(now())
+  channel        Channel  @relation(fields: [channel_id], references: [platform_id])
+  message        Message  @relation(fields: [message_id], references: [platform_id])
+  user           User     @relation(fields: [user_id], references: [platform_id])
 
-  @@unique([user_id, message_id])
+  @@unique([user_id, message_id, reaction_emoji])
   @@index([channel_id], map: "message_reaction_channel_id_fkey")
   @@index([message_id], map: "message_reaction_message_id_fkey")
   @@map("message_reaction")

--- a/src/infrastructure/persistence/repositories/MessageReactionRepository.ts
+++ b/src/infrastructure/persistence/repositories/MessageReactionRepository.ts
@@ -48,6 +48,8 @@ export class MessageReactionRepository implements IMessageReactionRepository {
           user: { connect: { platform_id: data.userId } },
           message: { connect: { platform_id: data.messageId } },
           channel: { connect: { platform_id: data.channelId } },
+          reaction_emoji: data.reactionEmoji ?? "",
+          reacted_at: data.reactedAt,
         },
         include: { user: true, message: true, channel: true },
       });
@@ -70,6 +72,8 @@ export class MessageReactionRepository implements IMessageReactionRepository {
           user_id: d.userId,
           message_id: d.messageId,
           channel_id: d.channelId,
+          reaction_emoji: d.reactionEmoji ?? "",
+          reacted_at: d.reactedAt,
         })),
         skipDuplicates: true,
       });
@@ -145,6 +149,32 @@ export class MessageReactionRepository implements IMessageReactionRepository {
     }
   }
 
+  async findByUserMessageAndEmoji(
+    userId: string,
+    messageId: string,
+    reactionEmoji: string,
+  ): Promise<MessageReactionEntity | null> {
+    try {
+      const result = await this.client.messageReaction.findFirst({
+        where: {
+          user_id: userId,
+          message_id: messageId,
+          reaction_emoji: reactionEmoji,
+        },
+        include: { user: true, message: true, channel: true },
+      });
+      return result ? this.toDomain(result) : null;
+    } catch (error) {
+      this.logger.logToConsole(
+        LoggerContextStatus.ERROR,
+        LoggerContext.REPOSITORY,
+        LoggerContextEntity.MESSAGE_REACTION,
+        `findByUserMessageAndEmoji | ${error.message}`,
+      );
+      return null;
+    }
+  }
+
   async updateMessageReaction(
     id: number,
     data: UpdateMessageReactionData,
@@ -157,6 +187,10 @@ export class MessageReactionRepository implements IMessageReactionRepository {
         persistenceData.message = { connect: { platform_id: data.messageId } };
       if (data.channelId)
         persistenceData.channel = { connect: { platform_id: data.channelId } };
+      if (data.reactionEmoji !== undefined)
+        persistenceData.reaction_emoji = data.reactionEmoji;
+      if (data.reactedAt !== undefined)
+        persistenceData.reacted_at = data.reactedAt;
 
       const result = await this.client.messageReaction.update({
         where: { id },
@@ -201,6 +235,13 @@ export class MessageReactionRepository implements IMessageReactionRepository {
     );
     const channel = PrismaMapper.toChannelEntity(reaction.channel);
 
-    return new MessageReactionEntity(reaction.id, user, message, channel);
+    return new MessageReactionEntity(
+      reaction.id,
+      user,
+      message,
+      channel,
+      reaction.reaction_emoji ?? undefined,
+      reaction.reacted_at ?? undefined,
+    );
   }
 }

--- a/src/infrastructure/persistence/repositories/PrismaMapper.ts
+++ b/src/infrastructure/persistence/repositories/PrismaMapper.ts
@@ -114,6 +114,8 @@ export class PrismaMapper {
       user && PrismaMapper.toUserEntity(user),
       message && PrismaMapper.toMessageEntity(message),
       channel && PrismaMapper.toChannelEntity(channel),
+      messageReact.reaction_emoji ?? undefined,
+      messageReact.reacted_at ?? undefined,
     );
   }
 

--- a/src/tests/command/messageReactionCommand.test.ts
+++ b/src/tests/command/messageReactionCommand.test.ts
@@ -2,6 +2,7 @@ import { MessageReactionCommand } from "@application/command/messageReactionComm
 import { IDiscordService } from "@services/IDiscordService";
 import { ILoggerService } from "@services/ILogger";
 import { IRegisterMessageReaction } from "@interfaces/useCases/messageReaction/IRegisterMessageReaction";
+import { IRemoveMessageReaction } from "@interfaces/useCases/messageReaction/IRemoveMessageReaction";
 import { Client, MessageReaction, User } from "discord.js";
 
 describe("MessageReactionCommand", () => {
@@ -20,10 +21,12 @@ describe("MessageReactionCommand", () => {
   >;
   let logger: jest.Mocked<ILoggerService>;
   let registerMessageReaction: jest.Mocked<IRegisterMessageReaction>;
+  let removeMessageReaction: jest.Mocked<IRemoveMessageReaction>;
 
   beforeEach(() => {
     discordService = {
       onReactionAdd: jest.fn(),
+      onReactionRemove: jest.fn(),
     } as unknown as jest.Mocked<
       IDiscordService<
         unknown,
@@ -44,12 +47,27 @@ describe("MessageReactionCommand", () => {
     registerMessageReaction = {
       execute: jest.fn().mockResolvedValue({ success: true, data: {} }),
     };
-    new MessageReactionCommand(discordService, logger, registerMessageReaction);
+    removeMessageReaction = {
+      execute: jest.fn().mockResolvedValue({ success: true, data: true }),
+    };
+    new MessageReactionCommand(
+      discordService,
+      logger,
+      registerMessageReaction,
+      removeMessageReaction,
+    );
   });
 
   it("should register onReactionAdd handler on discordService", () => {
     expect(discordService.onReactionAdd).toHaveBeenCalledTimes(1);
     expect(discordService.onReactionAdd).toHaveBeenCalledWith(
+      expect.any(Function),
+    );
+  });
+
+  it("should register onReactionRemove handler on discordService", () => {
+    expect(discordService.onReactionRemove).toHaveBeenCalledTimes(1);
+    expect(discordService.onReactionRemove).toHaveBeenCalledWith(
       expect.any(Function),
     );
   });
@@ -131,5 +149,60 @@ describe("MessageReactionCommand", () => {
     await handler(reactionMock, userMock);
 
     expect(registerMessageReaction.execute).not.toHaveBeenCalled();
+  });
+
+  it("should call removeMessageReaction.execute when remove handler is invoked", async () => {
+    const handler = (discordService.onReactionRemove as jest.Mock).mock
+      .calls[0][0];
+
+    const reactionMock = {
+      partial: false,
+      emoji: { name: "👍", id: null, identifier: "👍" },
+      message: {
+        id: "msg123",
+        partial: false,
+        fetch: jest.fn(),
+        channel: { id: "ch123" },
+        guild: null,
+        createdTimestamp: Date.now(),
+      },
+      fetch: jest.fn(),
+    };
+
+    const userMock = {
+      id: "user123",
+      bot: false,
+      username: "TestUser",
+    };
+
+    await handler(reactionMock, userMock);
+
+    expect(removeMessageReaction.execute).toHaveBeenCalledWith({
+      userId: "user123",
+      messageId: "msg123",
+      reactionEmoji: "👍",
+    });
+    expect(logger.logToConsole).toHaveBeenCalledWith(
+      "SUCCESS",
+      "COMMAND",
+      "MESSAGE_REACTION",
+      expect.stringMatching(/Reaction removed:.*user_id=user123/),
+    );
+  });
+
+  it("should not call remove use case when user is bot", async () => {
+    const handler = (discordService.onReactionRemove as jest.Mock).mock
+      .calls[0][0];
+
+    await handler(
+      {
+        partial: false,
+        emoji: { name: "👍", identifier: "👍" },
+        message: { id: "msg123", partial: false, channel: { id: "ch" } },
+      },
+      { id: "bot1", bot: true },
+    );
+
+    expect(removeMessageReaction.execute).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/command/messageReactionCommand.test.ts
+++ b/src/tests/command/messageReactionCommand.test.ts
@@ -1,0 +1,135 @@
+import { MessageReactionCommand } from "@application/command/messageReactionCommand";
+import { IDiscordService } from "@services/IDiscordService";
+import { ILoggerService } from "@services/ILogger";
+import { IRegisterMessageReaction } from "@interfaces/useCases/messageReaction/IRegisterMessageReaction";
+import { Client, MessageReaction, User } from "discord.js";
+
+describe("MessageReactionCommand", () => {
+  let discordService: jest.Mocked<
+    IDiscordService<
+      unknown,
+      unknown,
+      unknown,
+      Client,
+      unknown,
+      unknown,
+      unknown,
+      MessageReaction,
+      User
+    >
+  >;
+  let logger: jest.Mocked<ILoggerService>;
+  let registerMessageReaction: jest.Mocked<IRegisterMessageReaction>;
+
+  beforeEach(() => {
+    discordService = {
+      onReactionAdd: jest.fn(),
+    } as unknown as jest.Mocked<
+      IDiscordService<
+        unknown,
+        unknown,
+        unknown,
+        Client,
+        unknown,
+        unknown,
+        unknown,
+        MessageReaction,
+        User
+      >
+    >;
+    logger = {
+      logToConsole: jest.fn(),
+      logToDatabase: jest.fn(),
+    };
+    registerMessageReaction = {
+      execute: jest.fn().mockResolvedValue({ success: true, data: {} }),
+    };
+    new MessageReactionCommand(discordService, logger, registerMessageReaction);
+  });
+
+  it("should register onReactionAdd handler on discordService", () => {
+    expect(discordService.onReactionAdd).toHaveBeenCalledTimes(1);
+    expect(discordService.onReactionAdd).toHaveBeenCalledWith(
+      expect.any(Function),
+    );
+  });
+
+  it("should call registerMessageReaction.execute and log when handler is invoked", async () => {
+    const handler = (discordService.onReactionAdd as jest.Mock).mock
+      .calls[0][0];
+
+    const reactionMock = {
+      partial: false,
+      emoji: { name: "👍", id: null, identifier: "👍" },
+      message: {
+        id: "msg123",
+        partial: false,
+        fetch: jest.fn(),
+        channel: {
+          id: "ch123",
+          name: "general",
+          url: "https://discord.com/channels/guild/ch123",
+        },
+        guild: {
+          id: "guild1",
+          members: { resolve: jest.fn().mockReturnValue(null) },
+        },
+        createdTimestamp: Date.now(),
+      },
+      fetch: jest.fn(),
+    };
+
+    const userMock = {
+      id: "user123",
+      bot: false,
+      username: "TestUser",
+      globalName: "Test User",
+      createdTimestamp: Date.now(),
+    };
+
+    await handler(reactionMock, userMock);
+
+    expect(registerMessageReaction.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user123",
+        messageId: "msg123",
+        channelId: "ch123",
+        reactionEmoji: "👍",
+        username: "TestUser",
+      }),
+    );
+    expect(logger.logToConsole).toHaveBeenCalledWith(
+      "SUCCESS",
+      "COMMAND",
+      "MESSAGE_REACTION",
+      expect.stringMatching(/user_id=user123.*message_id=msg123.*reaction=/),
+    );
+  });
+
+  it("should not call use case when user is bot", async () => {
+    const handler = (discordService.onReactionAdd as jest.Mock).mock
+      .calls[0][0];
+
+    const reactionMock = {
+      partial: false,
+      emoji: { name: "👍", id: null, identifier: "👍" },
+      message: {
+        id: "msg123",
+        partial: false,
+        channel: { id: "ch123" },
+        guild: null,
+        createdTimestamp: Date.now(),
+      },
+    };
+
+    const userMock = {
+      id: "bot456",
+      bot: true,
+      username: "Bot",
+    };
+
+    await handler(reactionMock, userMock);
+
+    expect(registerMessageReaction.execute).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/config/constants.ts
+++ b/src/tests/config/constants.ts
@@ -530,12 +530,16 @@ export function createMockMessageReactionEntity(
   messageEntity?: MessageEntity,
   channelEntity?: ChannelEntity,
   id: number = 1,
+  reactionEmoji?: string,
+  reactedAt?: Date,
 ): MessageReactionEntity {
   return new MessageReactionEntity(
     id,
     userEntity ?? createMockUserEntity(),
     messageEntity ?? createMockMessageEntity(),
     channelEntity ?? createMockChannelEntity(),
+    reactionEmoji,
+    reactedAt,
   );
 }
 

--- a/src/tests/messageReaction/useCases/RegisterMessageReaction.test.ts
+++ b/src/tests/messageReaction/useCases/RegisterMessageReaction.test.ts
@@ -1,0 +1,439 @@
+import { RegisterMessageReaction } from "@domain/useCases/messageReaction/RegisterMessageReaction";
+import { IMessageReactionRepository } from "@repositories/IMessageReactionRepository";
+import { IUserRepository } from "@repositories/IUserRepository";
+import { IChannelRepository } from "@repositories/IChannelRepository";
+import { IMessageRepository } from "@repositories/IMessageRepository";
+import { ICreateUser } from "@interfaces/useCases/user/ICreateUser";
+import { ILoggerService } from "@services/ILogger";
+import { UserStatus } from "@type/UserStatusEnum";
+import {
+  createMockUserEntity,
+  createMockChannelEntity,
+  createMockMessageEntity,
+  createMockMessageReactionEntity,
+} from "@tests/config/constants";
+
+describe("RegisterMessageReaction", () => {
+  let registerMessageReaction: RegisterMessageReaction;
+  let mockMessageReactionRepository: jest.Mocked<IMessageReactionRepository>;
+  let mockUserRepository: jest.Mocked<IUserRepository>;
+  let mockChannelRepository: jest.Mocked<IChannelRepository>;
+  let mockMessageRepository: jest.Mocked<IMessageRepository>;
+  let mockCreateUser: jest.Mocked<ICreateUser>;
+  let mockLogger: jest.Mocked<ILoggerService>;
+
+  const mockChannel = createMockChannelEntity({
+    id: 1,
+    platformId: "channel123",
+    name: "Test Channel",
+    url: "https://discord.com/channels/123/channel123",
+  });
+
+  const mockUser = createMockUserEntity({
+    id: 1,
+    platformId: "user123",
+    username: "Test User",
+    bot: false,
+    status: UserStatus.ACTIVE,
+  });
+
+  const mockMessage = createMockMessageEntity({
+    id: 1,
+    platformId: "message123",
+    channel: mockChannel,
+    user: mockUser,
+    platformCreatedAt: new Date(),
+    isDeleted: false,
+    messageReactions: [],
+  });
+
+  const mockReaction = createMockMessageReactionEntity(
+    mockUser,
+    mockMessage,
+    mockChannel,
+    1,
+    "👍",
+    new Date(),
+  );
+
+  beforeEach(() => {
+    mockMessageReactionRepository = {
+      create: jest.fn(),
+      createMany: jest.fn(),
+      getMessageReactionById: jest.fn(),
+      getMessageReactionByUserId: jest.fn(),
+      getMessageReactionByUserPlatformId: jest.fn(),
+      findByUserMessageAndEmoji: jest.fn(),
+      updateMessageReaction: jest.fn(),
+      deleteMessageReaction: jest.fn(),
+    };
+
+    mockUserRepository = {
+      create: jest.fn(),
+      createMany: jest.fn(),
+      findById: jest.fn(),
+      findByPlatformId: jest.fn(),
+      listAll: jest.fn(),
+      updateById: jest.fn(),
+    };
+
+    mockChannelRepository = {
+      create: jest.fn(),
+      createMany: jest.fn(),
+      findById: jest.fn(),
+      findByPlatformId: jest.fn(),
+      listAll: jest.fn(),
+      updateById: jest.fn(),
+      deleteById: jest.fn(),
+    };
+
+    mockMessageRepository = {
+      create: jest.fn(),
+      createMany: jest.fn(),
+      findById: jest.fn(),
+      findByPlatformId: jest.fn(),
+      findByChannelId: jest.fn(),
+      findByUserId: jest.fn(),
+      listAll: jest.fn(),
+      updateById: jest.fn(),
+      deleteById: jest.fn(),
+    };
+
+    mockCreateUser = {
+      execute: jest.fn(),
+      executeMany: jest.fn(),
+    };
+
+    mockLogger = {
+      logToConsole: jest.fn(),
+      logToDatabase: jest.fn(),
+    };
+
+    registerMessageReaction = new RegisterMessageReaction(
+      mockMessageReactionRepository,
+      mockUserRepository,
+      mockChannelRepository,
+      mockMessageRepository,
+      mockCreateUser,
+      mockLogger,
+    );
+  });
+
+  describe("execute", () => {
+    it("should register reaction when user, channel and message exist", async () => {
+      const input = {
+        userId: "user123",
+        messageId: "message123",
+        channelId: "channel123",
+        reactionEmoji: "👍",
+      };
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(mockUser);
+      mockChannelRepository.findByPlatformId.mockResolvedValue(mockChannel);
+      mockMessageRepository.findByPlatformId.mockResolvedValue(mockMessage);
+      mockMessageReactionRepository.findByUserMessageAndEmoji.mockResolvedValue(
+        null,
+      );
+      mockMessageReactionRepository.create.mockResolvedValue(mockReaction);
+
+      const result = await registerMessageReaction.execute(input);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(mockReaction);
+      expect(
+        mockMessageReactionRepository.findByUserMessageAndEmoji,
+      ).toHaveBeenCalledWith("user123", "message123", "👍");
+      expect(mockMessageReactionRepository.create).toHaveBeenCalledWith({
+        userId: input.userId,
+        messageId: input.messageId,
+        channelId: input.channelId,
+        reactionEmoji: input.reactionEmoji,
+        reactedAt: undefined,
+      });
+      expect(mockLogger.logToConsole).toHaveBeenCalledWith(
+        "SUCCESS",
+        "USECASE",
+        "MESSAGE_REACTION",
+        expect.stringContaining("Reaction registered"),
+      );
+    });
+
+    it("should create user when user does not exist", async () => {
+      const input = {
+        userId: "user123",
+        messageId: "message123",
+        channelId: "channel123",
+        reactionEmoji: "❤️",
+        username: "New User",
+        userBot: false,
+      };
+
+      const createdUser = createMockUserEntity({
+        id: 1,
+        platformId: "user123",
+        username: "New User",
+        bot: false,
+        status: UserStatus.ACTIVE,
+      });
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(null);
+      mockCreateUser.execute.mockResolvedValue({
+        success: true,
+        data: createdUser,
+      });
+      mockChannelRepository.findByPlatformId.mockResolvedValue(mockChannel);
+      mockMessageRepository.findByPlatformId.mockResolvedValue(mockMessage);
+      mockMessageReactionRepository.findByUserMessageAndEmoji.mockResolvedValue(
+        null,
+      );
+      mockMessageReactionRepository.create.mockResolvedValue(mockReaction);
+
+      const result = await registerMessageReaction.execute(input);
+
+      expect(result.success).toBe(true);
+      expect(mockCreateUser.execute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          platformId: input.userId,
+          username: input.username,
+          bot: input.userBot ?? false,
+          status: UserStatus.ACTIVE,
+        }),
+      );
+      expect(mockMessageReactionRepository.create).toHaveBeenCalled();
+    });
+
+    it("should create channel when channel does not exist", async () => {
+      const input = {
+        userId: "user123",
+        messageId: "message123",
+        channelId: "channel123",
+        channelName: "New Channel",
+        channelUrl: "https://discord.com/channels/123/channel123",
+      };
+
+      const createdChannel = createMockChannelEntity({
+        id: 1,
+        platformId: "channel123",
+        name: "New Channel",
+        url: "https://discord.com/channels/123/channel123",
+      });
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(mockUser);
+      mockChannelRepository.findByPlatformId.mockResolvedValue(null);
+      mockChannelRepository.create.mockResolvedValue(createdChannel);
+      mockMessageRepository.findByPlatformId.mockResolvedValue(mockMessage);
+      mockMessageReactionRepository.findByUserMessageAndEmoji.mockResolvedValue(
+        null,
+      );
+      mockMessageReactionRepository.create.mockResolvedValue(mockReaction);
+
+      const result = await registerMessageReaction.execute(input);
+
+      expect(result.success).toBe(true);
+      expect(mockChannelRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          platformId: input.channelId,
+          name: input.channelName,
+          url: input.channelUrl,
+        }),
+      );
+      expect(mockMessageReactionRepository.create).toHaveBeenCalled();
+    });
+
+    it("should create message when message does not exist", async () => {
+      const input = {
+        userId: "user123",
+        messageId: "message123",
+        channelId: "channel123",
+        messagePlatformCreatedAt: new Date(),
+      };
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(mockUser);
+      mockChannelRepository.findByPlatformId.mockResolvedValue(mockChannel);
+      mockMessageRepository.findByPlatformId.mockRejectedValue(
+        new Error("Not found"),
+      );
+      mockMessageRepository.create.mockResolvedValue(mockMessage);
+      mockMessageReactionRepository.findByUserMessageAndEmoji.mockResolvedValue(
+        null,
+      );
+      mockMessageReactionRepository.create.mockResolvedValue(mockReaction);
+
+      const result = await registerMessageReaction.execute(input);
+
+      expect(result.success).toBe(true);
+      expect(mockMessageRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          platformId: input.messageId,
+          isDeleted: false,
+          channel: mockChannel,
+          user: mockUser,
+          messageReactions: [],
+        }),
+      );
+      expect(mockMessageReactionRepository.create).toHaveBeenCalled();
+    });
+
+    it("should return existing reaction when reaction already registered", async () => {
+      const input = {
+        userId: "user123",
+        messageId: "message123",
+        channelId: "channel123",
+        reactionEmoji: "👍",
+      };
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(mockUser);
+      mockChannelRepository.findByPlatformId.mockResolvedValue(mockChannel);
+      mockMessageRepository.findByPlatformId.mockResolvedValue(mockMessage);
+      mockMessageReactionRepository.findByUserMessageAndEmoji.mockResolvedValue(
+        mockReaction,
+      );
+
+      const result = await registerMessageReaction.execute(input);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(mockReaction);
+      expect(result.message).toBe("Reaction already registered");
+      expect(mockMessageReactionRepository.create).not.toHaveBeenCalled();
+      expect(mockLogger.logToConsole).toHaveBeenCalledWith(
+        "SUCCESS",
+        "USECASE",
+        "MESSAGE_REACTION",
+        expect.stringContaining("Reaction already registered"),
+      );
+    });
+
+    it("should return error when user data missing for user creation", async () => {
+      const input = {
+        userId: "user123",
+        messageId: "message123",
+        channelId: "channel123",
+      };
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(null);
+
+      const result = await registerMessageReaction.execute(input);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("User data required for user creation");
+      expect(mockCreateUser.execute).not.toHaveBeenCalled();
+      expect(mockMessageReactionRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("should return error when channel creation fails", async () => {
+      const input = {
+        userId: "user123",
+        messageId: "message123",
+        channelId: "channel123",
+        channelName: "New Channel",
+        channelUrl: "https://discord.com/channels/123/channel123",
+      };
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(mockUser);
+      mockChannelRepository.findByPlatformId.mockResolvedValue(null);
+      mockChannelRepository.create.mockResolvedValue(null);
+
+      const result = await registerMessageReaction.execute(input);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Failed to create channel");
+      expect(mockMessageReactionRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("should return error when message creation fails", async () => {
+      const input = {
+        userId: "user123",
+        messageId: "message123",
+        channelId: "channel123",
+      };
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(mockUser);
+      mockChannelRepository.findByPlatformId.mockResolvedValue(mockChannel);
+      mockMessageRepository.findByPlatformId.mockRejectedValue(
+        new Error("Not found"),
+      );
+      mockMessageRepository.create.mockResolvedValue(null);
+
+      const result = await registerMessageReaction.execute(input);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Failed to create message");
+      expect(mockMessageReactionRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("should return error when reaction create returns null", async () => {
+      const input = {
+        userId: "user123",
+        messageId: "message123",
+        channelId: "channel123",
+      };
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(mockUser);
+      mockChannelRepository.findByPlatformId.mockResolvedValue(mockChannel);
+      mockMessageRepository.findByPlatformId.mockResolvedValue(mockMessage);
+      mockMessageReactionRepository.findByUserMessageAndEmoji.mockResolvedValue(
+        null,
+      );
+      mockMessageReactionRepository.create.mockResolvedValue(null);
+
+      const result = await registerMessageReaction.execute(input);
+
+      expect(result.success).toBe(false);
+      expect(result.data).toBeNull();
+      expect(result.message).toBe("Unknown error occurred");
+    });
+
+    it("should handle repository errors and log them", async () => {
+      const input = {
+        userId: "user123",
+        messageId: "message123",
+        channelId: "channel123",
+      };
+
+      const error = new Error("Database connection failed");
+      mockUserRepository.findByPlatformId.mockRejectedValue(error);
+
+      const result = await registerMessageReaction.execute(input);
+
+      expect(result.success).toBe(false);
+      expect(result.data).toBeNull();
+      expect(result.message).toBe("Database connection failed");
+      expect(mockLogger.logToConsole).toHaveBeenCalledWith(
+        "ERROR",
+        "USECASE",
+        "MESSAGE_REACTION",
+        "registerMessageReaction.execute | Database connection failed",
+      );
+    });
+
+    it("should use empty string for reactionEmoji when not provided", async () => {
+      const input = {
+        userId: "user123",
+        messageId: "message123",
+        channelId: "channel123",
+      };
+
+      mockUserRepository.findByPlatformId.mockResolvedValue(mockUser);
+      mockChannelRepository.findByPlatformId.mockResolvedValue(mockChannel);
+      mockMessageRepository.findByPlatformId.mockResolvedValue(mockMessage);
+      mockMessageReactionRepository.findByUserMessageAndEmoji.mockResolvedValue(
+        null,
+      );
+      mockMessageReactionRepository.create.mockResolvedValue(mockReaction);
+
+      await registerMessageReaction.execute(input);
+
+      expect(
+        mockMessageReactionRepository.findByUserMessageAndEmoji,
+      ).toHaveBeenCalledWith("user123", "message123", "");
+      expect(mockMessageReactionRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "user123",
+          messageId: "message123",
+          channelId: "channel123",
+          reactionEmoji: undefined,
+        }),
+      );
+    });
+  });
+});

--- a/src/tests/messageReaction/useCases/RegisterMessageReaction.test.ts
+++ b/src/tests/messageReaction/useCases/RegisterMessageReaction.test.ts
@@ -390,19 +390,20 @@ describe("RegisterMessageReaction", () => {
         channelId: "channel123",
       };
 
-      const error = new Error("Database connection failed");
+      const errorMessage = "Database connection failed";
+      const error = new Error(errorMessage);
       mockUserRepository.findByPlatformId.mockRejectedValue(error);
 
       const result = await registerMessageReaction.execute(input);
 
       expect(result.success).toBe(false);
       expect(result.data).toBeNull();
-      expect(result.message).toBe("Database connection failed");
+      expect(result.message).toBe(errorMessage);
       expect(mockLogger.logToConsole).toHaveBeenCalledWith(
         "ERROR",
         "USECASE",
         "MESSAGE_REACTION",
-        "registerMessageReaction.execute | Database connection failed",
+        `registerMessageReaction.execute | ${errorMessage}`,
       );
     });
 

--- a/src/tests/messageReaction/useCases/RegisterMessageReaction.test.ts
+++ b/src/tests/messageReaction/useCases/RegisterMessageReaction.test.ts
@@ -274,7 +274,7 @@ describe("RegisterMessageReaction", () => {
       expect(mockMessageReactionRepository.create).toHaveBeenCalled();
     });
 
-    it("should return existing reaction when reaction already registered", async () => {
+    it("should return existing reaction when reaction registered", async () => {
       const input = {
         userId: "user123",
         messageId: "message123",
@@ -293,13 +293,13 @@ describe("RegisterMessageReaction", () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(mockReaction);
-      expect(result.message).toBe("Reaction already registered");
+      expect(result.message).toBe("Reaction registered");
       expect(mockMessageReactionRepository.create).not.toHaveBeenCalled();
       expect(mockLogger.logToConsole).toHaveBeenCalledWith(
         "SUCCESS",
         "USECASE",
         "MESSAGE_REACTION",
-        expect.stringContaining("Reaction already registered"),
+        expect.stringContaining("Reaction registered"),
       );
     });
 

--- a/src/tests/messageReaction/useCases/RemoveMessageReaction.test.ts
+++ b/src/tests/messageReaction/useCases/RemoveMessageReaction.test.ts
@@ -1,0 +1,170 @@
+import { RemoveMessageReaction } from "@domain/useCases/messageReaction/RemoveMessageReaction";
+import { IMessageReactionRepository } from "@repositories/IMessageReactionRepository";
+import { ILoggerService } from "@services/ILogger";
+import {
+  createMockUserEntity,
+  createMockChannelEntity,
+  createMockMessageEntity,
+  createMockMessageReactionEntity,
+} from "@tests/config/constants";
+import { UserStatus } from "@type/UserStatusEnum";
+import { ErrorMessages } from "@type/ErrorMessages";
+
+describe("RemoveMessageReaction", () => {
+  let removeMessageReaction: RemoveMessageReaction;
+  let mockMessageReactionRepository: jest.Mocked<IMessageReactionRepository>;
+  let mockLogger: jest.Mocked<ILoggerService>;
+
+  const mockChannel = createMockChannelEntity({
+    id: 1,
+    platformId: "channel123",
+    name: "Test Channel",
+    url: "https://discord.com/channels/123/channel123",
+  });
+
+  const mockUser = createMockUserEntity({
+    id: 1,
+    platformId: "user123",
+    username: "Test User",
+    bot: false,
+    status: UserStatus.ACTIVE,
+  });
+
+  const mockMessage = createMockMessageEntity({
+    id: 1,
+    platformId: "message123",
+    channel: mockChannel,
+    user: mockUser,
+    platformCreatedAt: new Date(),
+    isDeleted: false,
+    messageReactions: [],
+  });
+
+  const mockReaction = createMockMessageReactionEntity(
+    mockUser,
+    mockMessage,
+    mockChannel,
+    1,
+    "👍",
+    new Date(),
+  );
+
+  beforeEach(() => {
+    mockMessageReactionRepository = {
+      create: jest.fn(),
+      createMany: jest.fn(),
+      getMessageReactionById: jest.fn(),
+      getMessageReactionByUserId: jest.fn(),
+      getMessageReactionByUserPlatformId: jest.fn(),
+      findByUserMessageAndEmoji: jest.fn(),
+      updateMessageReaction: jest.fn(),
+      deleteMessageReaction: jest.fn(),
+    };
+
+    mockLogger = {
+      logToConsole: jest.fn(),
+      logToDatabase: jest.fn(),
+    };
+
+    removeMessageReaction = new RemoveMessageReaction(
+      mockMessageReactionRepository,
+      mockLogger,
+    );
+  });
+
+  it("finds reaction and deletes it", async () => {
+    mockMessageReactionRepository.findByUserMessageAndEmoji.mockResolvedValue(
+      mockReaction,
+    );
+    mockMessageReactionRepository.deleteMessageReaction.mockResolvedValue(true);
+
+    const result = await removeMessageReaction.execute({
+      userId: "user123",
+      messageId: "message123",
+      reactionEmoji: "👍",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBe(true);
+    expect(
+      mockMessageReactionRepository.findByUserMessageAndEmoji,
+    ).toHaveBeenCalledWith("user123", "message123", "👍");
+    expect(
+      mockMessageReactionRepository.deleteMessageReaction,
+    ).toHaveBeenCalledWith(mockReaction.id);
+  });
+
+  it("returns success when reaction is not in database (idempotent)", async () => {
+    mockMessageReactionRepository.findByUserMessageAndEmoji.mockResolvedValue(
+      null,
+    );
+
+    const result = await removeMessageReaction.execute({
+      userId: "user123",
+      messageId: "message123",
+      reactionEmoji: "👍",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBe(false);
+    expect(result.message).toBe("Reaction not in database");
+    expect(
+      mockMessageReactionRepository.deleteMessageReaction,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns failure when delete returns false", async () => {
+    mockMessageReactionRepository.findByUserMessageAndEmoji.mockResolvedValue(
+      mockReaction,
+    );
+    mockMessageReactionRepository.deleteMessageReaction.mockResolvedValue(
+      false,
+    );
+
+    const result = await removeMessageReaction.execute({
+      userId: "user123",
+      messageId: "message123",
+      reactionEmoji: "👍",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.data).toBe(false);
+    expect(result.message).toBe(ErrorMessages.UNKNOWN_ERROR);
+  });
+
+  it("returns failure and logs on repository error", async () => {
+    mockMessageReactionRepository.findByUserMessageAndEmoji.mockRejectedValue(
+      new Error("db down"),
+    );
+
+    const result = await removeMessageReaction.execute({
+      userId: "user123",
+      messageId: "message123",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.data).toBe(false);
+    expect(result.message).toBe("db down");
+    expect(mockLogger.logToConsole).toHaveBeenCalledWith(
+      "ERROR",
+      "USECASE",
+      "MESSAGE_REACTION",
+      expect.stringContaining("removeMessageReaction.execute"),
+    );
+  });
+
+  it("uses empty string for reactionEmoji when omitted", async () => {
+    mockMessageReactionRepository.findByUserMessageAndEmoji.mockResolvedValue(
+      null,
+    );
+
+    await removeMessageReaction.execute({
+      userId: "user123",
+      messageId: "message123",
+    });
+
+    expect(
+      mockMessageReactionRepository.findByUserMessageAndEmoji,
+    ).toHaveBeenCalledWith("user123", "message123", "");
+  });
+});


### PR DESCRIPTION
## Descrição

Queremos criar o use case MessageReaction que registre uma reação de acordo com uma mensagem com detalhes de data, id do usuário e código do icon da reação quando o evento de reactions.

## Link da tarefa

<!-- Adicione aqui o link da tarefa no Jira, Trello ou qualquer ferramenta de gestão de tarefas. -->

[CPDD-29](https://www.notion.so/cpdd/useCases-MessageReaction-Registrar-evento-do-discord-de-rea-o-a-uma-mensagem-2d0c5f6d25f881c1b868e023ccf7d97f?v=a15bd28b53104ced8d9d79127f4eea16&source=copy_link)

## Tipo de mudança

- [ ] Bugfix
- [X] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

## Como foi testado?

<img width="1877" height="143" alt="image" src="https://github.com/user-attachments/assets/3b2fa946-a6e6-46ac-9003-588b6fafe9de" />

<img width="1879" height="235" alt="image" src="https://github.com/user-attachments/assets/9fe3ad7b-1960-4537-a2ce-67987decbe83" />


## Checklist

- [ ] Código segue o padrão de estilo do projeto
- [ ] Testes unitários foram adicionados
- [ ] A documentação foi atualizada (se aplicável)
