### PR TITLE
CPDD-131 - Cria canal faltante quando ha atualizacao

### DIFF
--- a/src/domain/useCases/channel/DeleteChannel.ts
+++ b/src/domain/useCases/channel/DeleteChannel.ts
@@ -29,6 +29,7 @@ export class DeleteChannel implements IDeleteChannel {
           LoggerContextEntity.CHANNEL,
           `DeleteChannel.execute | ${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
         );
+        return;
       }
 
       const isDeleted = await this.channelRepository.deleteById(channel.id);

--- a/src/domain/useCases/channel/UpdateChannel.ts
+++ b/src/domain/useCases/channel/UpdateChannel.ts
@@ -3,7 +3,6 @@ import { IChannelRepository } from "@domain/interfaces/repositories/IChannelRepo
 import { ILoggerService } from "@domain/interfaces/services/ILogger";
 import { ChannelIdType } from "@domain/interfaces/useCases/channel/IChannelId";
 import { IUpdateChannel } from "@domain/interfaces/useCases/channel/IUpdateChannel";
-import { ErrorMessages } from "@domain/types/ErrorMessages";
 import {
   LoggerContext,
   LoggerContextEntity,
@@ -27,12 +26,22 @@ export class UpdateChannel implements IUpdateChannel {
           : await this.channelRepository.findById(id);
 
       if (!channel) {
+        const channelData: Omit<ChannelEntity, "id"> = {
+          platformId: data.platformId ?? (typeof id === "string" ? id : ""),
+          name: data.name ?? "Unknown Channel",
+          url: data.url ?? "",
+          createdAt: data.createdAt ?? new Date(),
+        };
+
+        await this.channelRepository.create(channelData);
+
         this.logger.logToConsole(
-          LoggerContextStatus.ERROR,
+          LoggerContextStatus.SUCCESS,
           LoggerContext.USECASE,
           LoggerContextEntity.CHANNEL,
-          `UpdateChannel.execute | ${ErrorMessages.CHANNEL_NOT_FOUND} ${id}`,
+          `Canal ${channelData.platformId} - ${channelData.name} criado no Use Case de atualizacao`,
         );
+        return;
       }
 
       const updatedChannel = await this.channelRepository.updateById(

--- a/src/tests/channel/channelUseCases.test.ts
+++ b/src/tests/channel/channelUseCases.test.ts
@@ -153,7 +153,7 @@ describe("Channel useCases", () => {
       );
     });
 
-    it("should returns a not found response when channel not found", async () => {
+    it("should create channel when not found during update", async () => {
       const id = 1;
       const channelChangedData = {
         platformId: "1234567890",
@@ -166,6 +166,14 @@ describe("Channel useCases", () => {
 
       expect(channelRepository.findById).toHaveBeenCalledTimes(1);
       expect(channelRepository.findById).toHaveBeenCalledWith(id);
+      expect(channelRepository.create).toHaveBeenCalledTimes(1);
+      expect(channelRepository.create).toHaveBeenCalledWith(channelChangedData);
+      expect(loggerMock.logToConsole).toHaveBeenCalledWith(
+        LoggerContextStatus.SUCCESS,
+        LoggerContext.USECASE,
+        LoggerContextEntity.CHANNEL,
+        `Canal ${channelChangedData.platformId} - ${channelChangedData.name} criado no Use Case de atualizacao`,
+      );
       expect(channelRepository.updateById).not.toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
## Descrição

Há um bug na lógica de tratamento de evento de atualização de canal. 
Quando o canal não existe no BD e há um evento de atualização do canal, existe uma verificação de existência do canal. Entretanto, quando o canal não é encontrado, apenas fazemos o log mas não interrompemos a execução. Isso quer dizer que a função assume que o canal existe e procede no processo de atualização, o que causa erro.

A solução implementada resolve o problema da seguinte forma: quando há um evento de atualização de canal mas não encontramos o canal, o canal é criado com os dados novos, fazemos log deste caso específico, e interrompemos a execução da atualização. A interrupção faz sentido já que acabamos de criar o canal com os dados novos; não há nada a atualizar.

## Link da tarefa

CPDD-131

## Tipo de mudança

- [x] Bugfix
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

## Como foi testado?
Para a reprodução do bug e teste da solução, é importante que após o bot subir, não haver nenhuma interação com o canal a ser testado. Isso é importante pois, por exemplo, enviar uma mensagem no canal faltante faz com que o canal seja criado.

### Reprodução do bug 
1. Criar canal (texto, voz, fórum)
2. Iniciar o bot
3. Editar o canal, por exemplo, nome.
4. Haverá um log de que houve erro, como a seguir
4.1. `{"id":1773078371380,"status":"ERROR","context":"USECASE","entity":"CHANNEL","message":"UpdateChannel.execute | Channel not found with id 1349030286578679850","createdAt":"2026-03-09T17:46:11.380Z"}`

### Testando a solução 
1. Criar canal (texto, voz, fórum)
2. Iniciar o bot
3. Editar o canal, por exemplo, nome.
4. Haverá um log de que o canal foi criado no use case de atualização
4.1. `{"id":1775002643702,"status":"SUCCESS","context":"USECASE","entity":"CHANNEL","message":"Canal 1488677083012927570 - 111 criado no Use Case de atualizacao","createdAt":"2026-04-01T00:17:23.702Z"}`


## Checklist

- [x] Código segue o padrão de estilo do projeto
- [x] Testes unitários foram adicionados
- [ ] A documentação foi atualizada (se aplicável)
