### PR TITLE
chore(github-actions): adiciona workflow de deploy na Digital Ocean

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to Droplet - Checkin
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Add known hosts
+        run: |
+          ssh-keyscan -H ${{ secrets.DROPLET_IP }} >> ~/.ssh/known_hosts
+
+      - name: Deploy to Droplet
+        env:
+          DROPLET_USER: ${{ secrets.DROPLET_USER }}
+          DROPLET_IP: ${{ secrets.DROPLET_IP }}
+          PROJECT_PATH: ${{ secrets.CHECKIN_PROJECT_PATH }}
+        run: |
+          echo "Connecting to droplet..."
+          ssh -o StrictHostKeyChecking=no ${DROPLET_USER}@${DROPLET_IP} << EOF
+            echo "Connected. Navigating to: ${PROJECT_PATH}"
+            cd ${PROJECT_PATH}
+            echo "Pulling latest changes from main..."
+            git pull origin main
+            echo "Rebuilding and restarting containers..."
+            docker compose --profile prod up -d --build
+            echo "Deploy finished!"
+          EOF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to Droplet - Checkin
 on:
   push:
     branches:
-      - main
+      - homol
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to Droplet - Checkin
 on:
   push:
     branches:
-      - homol
+      - main
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -29,13 +27,6 @@ jobs:
           DROPLET_IP: ${{ secrets.DROPLET_IP }}
           PROJECT_PATH: ${{ secrets.CHECKIN_PROJECT_PATH }}
         run: |
-          echo "Connecting to droplet..."
-          ssh -o StrictHostKeyChecking=no ${DROPLET_USER}@${DROPLET_IP} << EOF
-            echo "Connected. Navigating to: ${PROJECT_PATH}"
-            cd ${PROJECT_PATH}
-            echo "Pulling latest changes from main..."
-            git pull origin main
-            echo "Rebuilding and restarting containers..."
-            docker compose --profile prod up -d --build
-            echo "Deploy finished!"
-          EOF
+          SAFE_PATH=$(printf '%q' "${PROJECT_PATH}")
+          ssh "${DROPLET_USER}@${DROPLET_IP}" \
+            "set -e && cd ${SAFE_PATH} && git pull origin main && docker compose --profile prod up -d --build"


### PR DESCRIPTION
## Descrição

Adiciona pipeline de CD via GitHub Actions para deploy automático na Digital Ocean, seguindo as mesmas premissas e boas práticas já utilizadas na landing page.

## Mudanças

- Criado `.github/workflows/deploy.yml` com:
  - Trigger em push na `main`
  - Suporte a `workflow_dispatch` para acionamento manual
  - SSH via `webfactory/ssh-agent@v0.9.0`
  - Deploy com `git pull` + `docker compose --profile prod up -d --build`

## Secrets necessários

| Secret | Descrição |
|---|---|
| `SSH_PRIVATE_KEY` | Chave SSH privada do Droplet |
| `DROPLET_USER` | Usuário SSH |
| `DROPLET_IP` | IP do Droplet |
| `CHECKIN_PROJECT_PATH` | Caminho do projeto no servidor |

## Tipo de mudança

- [ ] Bugfix
- [ ] Nova funcionalidade
- [ ] Refatoração
- [x] Chore / Infraestrutura

## Como foi testado?

- Validado localmente a sintaxe do workflow
- Estrutura baseada no deploy já funcional da landing page

## Checklist

- [x] Segue o estilo de código do projeto
- [x] Não expõe secrets ou credenciais
- [x] Secrets necessários documentados acima