### PR TITLE
CPDD-139 - Docker build + tag + push quando criar GH tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,72 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine branch for tag
+        id: branch-check
+        run: |
+          TAG_COMMIT=$(git rev-parse HEAD)
+          if git branch -r --contains "$TAG_COMMIT" | grep -qE "origin/main$"; then
+            echo "branch=main" >> $GITHUB_OUTPUT
+          elif git branch -r --contains "$TAG_COMMIT" | grep -qE "origin/homol$"; then
+            echo "branch=homol" >> $GITHUB_OUTPUT
+          elif git branch -r --contains "$TAG_COMMIT" | grep -qE "origin/CPDD-139$"; then
+            echo "branch=CPDD-139" >> $GITHUB_OUTPUT
+          else
+            echo "branch=none" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set image name
+        run: echo "IMAGE_NAME=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Set image tags
+        id: image-tags
+        if: steps.branch-check.outputs.branch != 'none'
+        run: |
+          GIT_TAG="${GITHUB_REF_NAME}"
+          BRANCH="${{ steps.branch-check.outputs.branch }}"
+          if [ "$BRANCH" = "main" ]; then
+            echo "tags=${IMAGE_NAME}:${GIT_TAG},${IMAGE_NAME}:latest" >> $GITHUB_OUTPUT
+          else
+            echo "tags=${IMAGE_NAME}:${GIT_TAG}-${BRANCH},${IMAGE_NAME}:${BRANCH}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Log in to GitHub Container Registry
+        if: steps.branch-check.outputs.branch != 'none'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.branch-check.outputs.branch != 'none'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        if: steps.branch-check.outputs.branch != 'none'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Containerfile
+          push: true
+          tags: ${{ steps.image-tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,8 +27,6 @@ jobs:
             echo "branch=main" >> $GITHUB_OUTPUT
           elif git branch -r --contains "$TAG_COMMIT" | grep -qE "origin/homol$"; then
             echo "branch=homol" >> $GITHUB_OUTPUT
-          elif git branch -r --contains "$TAG_COMMIT" | grep -qE "origin/CPDD-139$"; then
-            echo "branch=CPDD-139" >> $GITHUB_OUTPUT
           else
             echo "branch=none" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Build and Push Docker Image
 on:
   push:
     tags:
-      - 'v*'
+      - '[0-9]*'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Descrição

Criação de `.github/workflows/docker-publish.yml` para construir imagem Docker quando criarmos uma tag em `homol` ou `main`. A imagem será hospedada inicialmente no GHCR.

## Link da tarefa

CPDD-139

## Tipo de mudança

- [ ] Bugfix
- [X] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

## Como foi testado?

Github Action temporariamente aceitando tags desta branch (CPDD-139) e tags foram criadas. Foi verificado que a imagem foi construída e hospedada no GHCR.

Podemos ver a versão salva no GHCR [aqui](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/pkgs/container/checkin-discord-bot-v1/versions?filters%5Bversion_type%5D=tagged)

## Checklist

- [ ] Código segue o padrão de estilo do projeto
- [ ] Testes unitários foram adicionados
- [ ] A documentação foi atualizada (se aplicável)
