### PR TITLE
fix(historical-sync): torna sync histórico mais resiliente a falhas

### DIFF
--- a/src/contexts/useHistoricalSyncCases.context.ts
+++ b/src/contexts/useHistoricalSyncCases.context.ts
@@ -22,7 +22,7 @@ export function initializeHistoricalSyncUseCases(
   const prismaClient = new PrismaClient();
   const prismaService = new PrismaService(prismaClient);
 
-  const discordHistoryFetcher = new DiscordHistoryFetcher(client);
+  const discordHistoryFetcher = new DiscordHistoryFetcher(client, logger);
   const historicalImportRepository = new HistoricalImportRepository(
     prismaService,
     logger,

--- a/src/domain/useCases/message/ImportMessages.ts
+++ b/src/domain/useCases/message/ImportMessages.ts
@@ -39,6 +39,8 @@ export class ImportMessages implements IImportMessages {
       failed: 0,
     };
 
+    const failedBatches: number[] = [];
+
     try {
       let cursor: MessageHistoryCursor | undefined;
       let done = false;
@@ -55,42 +57,63 @@ export class ImportMessages implements IImportMessages {
         totals.fetched += batch.messages.length;
 
         if (batch.messages.length > 0) {
-          const { channels, users } = this.buildUniqueChannelsAndUsers(
-            batch.messages,
-          );
-          const messages = batch.messages.map((raw) =>
-            this.toMessageEntity(raw, channels, users),
-          );
+          try {
+            const { channels, users } = this.buildUniqueChannelsAndUsers(
+              batch.messages,
+            );
+            const messages = batch.messages.map((raw) =>
+              this.toMessageEntity(raw, channels, users),
+            );
 
-          const saveResult =
-            await this.historicalImportRepository.saveMessagesBatch({
-              channels: [...channels.values()],
-              users: [...users.values()],
-              messages,
+            const saveResult =
+              await this.historicalImportRepository.saveMessagesBatch({
+                channels: [...channels.values()],
+                users: [...users.values()],
+                messages,
+              });
+
+            totals.created += saveResult.messagesCreated;
+            totals.skipped += messages.length - saveResult.messagesCreated;
+
+            this.logger.logToConsole(
+              LoggerContextStatus.SUCCESS,
+              LoggerContext.USECASE,
+              LoggerContextEntity.HISTORICAL_SYNC,
+              `ImportMessages | lote ${batchNumber}: fetched=${batch.messages.length} created=${saveResult.messagesCreated}`,
+            );
+
+            input.onProgress?.({
+              batchNumber,
+              fetched: totals.fetched,
+              created: totals.created,
             });
-
-          totals.created += saveResult.messagesCreated;
-          totals.skipped += messages.length - saveResult.messagesCreated;
-
-          this.logger.logToConsole(
-            LoggerContextStatus.SUCCESS,
-            LoggerContext.USECASE,
-            LoggerContextEntity.HISTORICAL_SYNC,
-            `ImportMessages | lote ${batchNumber}: fetched=${batch.messages.length} created=${saveResult.messagesCreated}`,
-          );
-
-          input.onProgress?.({
-            batchNumber,
-            fetched: totals.fetched,
-            created: totals.created,
-          });
+          } catch (batchError) {
+            totals.failed += batch.messages.length;
+            failedBatches.push(batchNumber);
+            const platformIds = batch.messages
+              .map((message) => message.platformId)
+              .join(", ");
+            this.logger.logToConsole(
+              LoggerContextStatus.ERROR,
+              LoggerContext.USECASE,
+              LoggerContextEntity.HISTORICAL_SYNC,
+              `ImportMessages | lote ${batchNumber} falhou (mensagens: ${platformIds}) | ${batchError instanceof Error ? batchError.message : String(batchError)}`,
+            );
+          }
         }
 
         cursor = batch.cursor;
         done = batch.done;
       }
 
-      return { data: totals, success: true };
+      return {
+        data: totals,
+        success: failedBatches.length === 0,
+        message:
+          failedBatches.length > 0
+            ? `lote(s) ${failedBatches.join(", ")} falharam ao salvar (${totals.failed} mensagens)`
+            : undefined,
+      };
     } catch (error) {
       totals.failed = totals.fetched - totals.created - totals.skipped;
       this.logger.logToConsole(

--- a/src/domain/useCases/messageReaction/ImportMessageReactions.ts
+++ b/src/domain/useCases/messageReaction/ImportMessageReactions.ts
@@ -99,7 +99,7 @@ export class ImportMessageReactions implements IImportMessageReactions {
               LoggerContextStatus.ERROR,
               LoggerContext.USECASE,
               LoggerContextEntity.HISTORICAL_SYNC,
-              `ImportMessageReactions | lote ${batchNumber} falhou (mensagens referenciadas: ${messageIds}) | ${batchError instanceof Error ? batchError.message : String(batchError)}`,
+              `ImportMessageReactions | batch ${batchNumber} failed (referenced messages: ${messageIds}) | ${batchError instanceof Error ? batchError.message : String(batchError)}`,
             );
           }
         }
@@ -113,7 +113,7 @@ export class ImportMessageReactions implements IImportMessageReactions {
         success: failedBatches.length === 0,
         message:
           failedBatches.length > 0
-            ? `lote(s) ${failedBatches.join(", ")} falharam ao salvar (${totals.failed} reações)`
+            ? `batch(es) ${failedBatches.join(", ")} failed to save (${totals.failed} reactions)`
             : undefined,
       };
     } catch (error) {

--- a/src/domain/useCases/messageReaction/ImportMessageReactions.ts
+++ b/src/domain/useCases/messageReaction/ImportMessageReactions.ts
@@ -41,6 +41,8 @@ export class ImportMessageReactions implements IImportMessageReactions {
       failed: 0,
     };
 
+    const failedBatches: number[] = [];
+
     try {
       let cursor: MessageHistoryCursor | undefined;
       let done = false;
@@ -58,42 +60,62 @@ export class ImportMessageReactions implements IImportMessageReactions {
         totals.fetched += batch.reactions.length;
 
         if (batch.reactions.length > 0) {
-          const { channels, users } = this.buildUniqueChannelsAndUsers(
-            batch.reactions,
-          );
-          const reactions: RawMessageReactionAssignment[] = batch.reactions.map(
-            (raw) => this.toReactionAssignment(raw),
-          );
+          try {
+            const { channels, users } = this.buildUniqueChannelsAndUsers(
+              batch.reactions,
+            );
+            const reactions: RawMessageReactionAssignment[] =
+              batch.reactions.map((raw) => this.toReactionAssignment(raw));
 
-          const saveResult =
-            await this.historicalImportRepository.saveMessageReactionsBatch({
-              channels: [...channels.values()],
-              users: [...users.values()],
-              reactions,
+            const saveResult =
+              await this.historicalImportRepository.saveMessageReactionsBatch({
+                channels: [...channels.values()],
+                users: [...users.values()],
+                reactions,
+              });
+
+            totals.created += saveResult.reactionsCreated;
+            totals.skipped += reactions.length - saveResult.reactionsCreated;
+
+            this.logger.logToConsole(
+              LoggerContextStatus.SUCCESS,
+              LoggerContext.USECASE,
+              LoggerContextEntity.HISTORICAL_SYNC,
+              `ImportMessageReactions | lote ${batchNumber}: fetched=${batch.reactions.length} created=${saveResult.reactionsCreated}`,
+            );
+
+            input.onProgress?.({
+              batchNumber,
+              fetched: totals.fetched,
+              created: totals.created,
             });
-
-          totals.created += saveResult.reactionsCreated;
-          totals.skipped += reactions.length - saveResult.reactionsCreated;
-
-          this.logger.logToConsole(
-            LoggerContextStatus.SUCCESS,
-            LoggerContext.USECASE,
-            LoggerContextEntity.HISTORICAL_SYNC,
-            `ImportMessageReactions | lote ${batchNumber}: fetched=${batch.reactions.length} created=${saveResult.reactionsCreated}`,
-          );
-
-          input.onProgress?.({
-            batchNumber,
-            fetched: totals.fetched,
-            created: totals.created,
-          });
+          } catch (batchError) {
+            totals.failed += batch.reactions.length;
+            failedBatches.push(batchNumber);
+            const messageIds = [
+              ...new Set(batch.reactions.map((reaction) => reaction.messageId)),
+            ].join(", ");
+            this.logger.logToConsole(
+              LoggerContextStatus.ERROR,
+              LoggerContext.USECASE,
+              LoggerContextEntity.HISTORICAL_SYNC,
+              `ImportMessageReactions | lote ${batchNumber} falhou (mensagens referenciadas: ${messageIds}) | ${batchError instanceof Error ? batchError.message : String(batchError)}`,
+            );
+          }
         }
 
         cursor = batch.cursor;
         done = batch.done;
       }
 
-      return { data: totals, success: true };
+      return {
+        data: totals,
+        success: failedBatches.length === 0,
+        message:
+          failedBatches.length > 0
+            ? `lote(s) ${failedBatches.join(", ")} falharam ao salvar (${totals.failed} reações)`
+            : undefined,
+      };
     } catch (error) {
       totals.failed = totals.fetched - totals.created - totals.skipped;
       this.logger.logToConsole(

--- a/src/infrastructure/discord/fetchers/DiscordHistoryFetcher.ts
+++ b/src/infrastructure/discord/fetchers/DiscordHistoryFetcher.ts
@@ -275,7 +275,7 @@ export class DiscordHistoryFetcher implements IDiscordHistoryFetcher {
             LoggerContextStatus.ERROR,
             LoggerContext.USECASE,
             LoggerContextEntity.HISTORICAL_SYNC,
-            `DiscordHistoryFetcher.walkMessagesInRange | sem acesso ao canal #${channel.name} (${channel.id}), pulando`,
+            `DiscordHistoryFetcher.walkMessagesInRange | no access to channel #${channel.name} (${channel.id}), skipping`,
           );
           channelIndex += 1;
           before = undefined;

--- a/src/infrastructure/discord/fetchers/DiscordHistoryFetcher.ts
+++ b/src/infrastructure/discord/fetchers/DiscordHistoryFetcher.ts
@@ -26,11 +26,26 @@ import {
   mapDiscordScheduledEventStatus,
   mapEventStatusToPlatformId,
 } from "@type/DiscordEventTypes";
+import { ILoggerService } from "@services/ILogger";
+import {
+  LoggerContext,
+  LoggerContextEntity,
+  LoggerContextStatus,
+} from "@type/LoggerContextEnum";
 
 const MAX_PAGE_SIZE = 100;
+const MISSING_ACCESS_ERROR_CODE = 50001;
 
 export class DiscordHistoryFetcher implements IDiscordHistoryFetcher {
-  constructor(private readonly client: Client) {}
+  private guildMembersPromise?: Promise<{
+    guild: Guild;
+    members: Collection<string, GuildMember>;
+  }>;
+
+  constructor(
+    private readonly client: Client,
+    private readonly logger?: ILoggerService,
+  ) {}
 
   async fetchNextMessageBatch(
     input: FetchNextMessageBatchInput,
@@ -223,19 +238,24 @@ export class DiscordHistoryFetcher implements IDiscordHistoryFetcher {
     guild: Guild;
     members: Collection<string, GuildMember>;
   }> {
-    const guild = await this.resolveGuild();
-    const members = await guild.members.fetch();
-    return { guild, members };
+    if (!this.guildMembersPromise) {
+      this.guildMembersPromise = (async () => {
+        const guild = await this.resolveGuild();
+        const members = await guild.members.fetch();
+        return { guild, members };
+      })().catch((error) => {
+        this.guildMembersPromise = undefined;
+        throw error;
+      });
+    }
+    return this.guildMembersPromise;
   }
 
   private async walkMessagesInRange(
     channels: TextChannel[],
     range: { startDate: Date; endDate: Date; cursor?: MessageHistoryCursor },
     hasCapacity: () => boolean,
-    onMessage: (
-      message: Message,
-      channel: TextChannel,
-    ) => Promise<void> | void,
+    onMessage: (message: Message, channel: TextChannel) => Promise<void> | void,
   ): Promise<{ cursor: MessageHistoryCursor; done: boolean }> {
     const { startDate, endDate, cursor } = range;
     let channelIndex = cursor?.channelIndex ?? 0;
@@ -243,10 +263,26 @@ export class DiscordHistoryFetcher implements IDiscordHistoryFetcher {
 
     while (channelIndex < channels.length && hasCapacity()) {
       const channel = channels[channelIndex];
-      const page = await channel.messages.fetch({
-        limit: MAX_PAGE_SIZE,
-        ...(before ? { before } : {}),
-      });
+      let page: Collection<string, Message>;
+      try {
+        page = await channel.messages.fetch({
+          limit: MAX_PAGE_SIZE,
+          ...(before ? { before } : {}),
+        });
+      } catch (error) {
+        if (this.isMissingAccessError(error)) {
+          this.logger?.logToConsole(
+            LoggerContextStatus.ERROR,
+            LoggerContext.USECASE,
+            LoggerContextEntity.HISTORICAL_SYNC,
+            `DiscordHistoryFetcher.walkMessagesInRange | sem acesso ao canal #${channel.name} (${channel.id}), pulando`,
+          );
+          channelIndex += 1;
+          before = undefined;
+          continue;
+        }
+        throw error;
+      }
 
       if (page.size === 0) {
         channelIndex += 1;
@@ -282,6 +318,15 @@ export class DiscordHistoryFetcher implements IDiscordHistoryFetcher {
 
     const done = channelIndex >= channels.length;
     return { cursor: { channelIndex, before }, done };
+  }
+
+  private isMissingAccessError(error: unknown): boolean {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code: unknown }).code === MISSING_ACCESS_ERROR_CODE
+    );
   }
 
   private listTextChannels(guild: Guild): TextChannel[] {

--- a/src/tests/message/useCases/ImportMessages.test.ts
+++ b/src/tests/message/useCases/ImportMessages.test.ts
@@ -218,6 +218,46 @@ describe("ImportMessages", () => {
     });
   });
 
+  it("should log the failed batch and continue to the next one when saveMessagesBatch throws", async () => {
+    mockFetcher.fetchNextMessageBatch
+      .mockResolvedValueOnce({
+        messages: [rawMessage({ platformId: "message-1" })],
+        cursor: { channelIndex: 0, before: "message-1" },
+        done: false,
+      })
+      .mockResolvedValueOnce({
+        messages: [rawMessage({ platformId: "message-2" })],
+        cursor: { channelIndex: 1 },
+        done: true,
+      });
+
+    mockRepository.saveMessagesBatch
+      .mockRejectedValueOnce(new Error("connection lost"))
+      .mockResolvedValueOnce({
+        channelsUpserted: 1,
+        usersUpserted: 1,
+        messagesCreated: 1,
+      });
+
+    const result = await importMessages.execute(input);
+
+    expect(mockFetcher.fetchNextMessageBatch).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("lote(s) 1");
+    expect(result.data).toEqual({
+      fetched: 2,
+      created: 1,
+      skipped: 0,
+      failed: 1,
+    });
+    expect(mockLogger.logToConsole).toHaveBeenCalledWith(
+      "ERROR",
+      "USECASE",
+      "HISTORICAL_SYNC",
+      expect.stringContaining("lote 1 falhou (mensagens: message-1)"),
+    );
+  });
+
   it("should handle fetcher errors and report failure", async () => {
     mockFetcher.fetchNextMessageBatch.mockRejectedValue(
       new Error("Discord API unavailable"),

--- a/src/tests/messageReaction/useCases/ImportMessageReactions.test.ts
+++ b/src/tests/messageReaction/useCases/ImportMessageReactions.test.ts
@@ -244,6 +244,50 @@ describe("ImportMessageReactions", () => {
     });
   });
 
+  it("should log the failed batch (with referenced message ids) and continue to the next one when saveMessageReactionsBatch throws", async () => {
+    mockFetcher.fetchNextMessageReactionsBatch
+      .mockResolvedValueOnce({
+        reactions: [rawReaction({ messageId: "message-orphan" })],
+        cursor: { channelIndex: 0, before: "message-orphan" },
+        done: false,
+      })
+      .mockResolvedValueOnce({
+        reactions: [rawReaction({ messageId: "message-2" })],
+        cursor: { channelIndex: 1 },
+        done: true,
+      });
+
+    mockRepository.saveMessageReactionsBatch
+      .mockRejectedValueOnce(
+        new Error("referenced message(s) not found: message-orphan"),
+      )
+      .mockResolvedValueOnce({
+        channelsUpserted: 1,
+        usersUpserted: 1,
+        reactionsCreated: 1,
+      });
+
+    const result = await importMessageReactions.execute(input);
+
+    expect(mockFetcher.fetchNextMessageReactionsBatch).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("lote(s) 1");
+    expect(result.data).toEqual({
+      fetched: 2,
+      created: 1,
+      skipped: 0,
+      failed: 1,
+    });
+    expect(mockLogger.logToConsole).toHaveBeenCalledWith(
+      "ERROR",
+      "USECASE",
+      "HISTORICAL_SYNC",
+      expect.stringContaining(
+        "lote 1 falhou (mensagens referenciadas: message-orphan)",
+      ),
+    );
+  });
+
   it("should handle fetcher errors and report failure isolated from other batches", async () => {
     mockFetcher.fetchNextMessageReactionsBatch.mockRejectedValue(
       new Error("message not persisted"),

--- a/src/tests/messageReaction/useCases/ImportMessageReactions.test.ts
+++ b/src/tests/messageReaction/useCases/ImportMessageReactions.test.ts
@@ -271,7 +271,7 @@ describe("ImportMessageReactions", () => {
 
     expect(mockFetcher.fetchNextMessageReactionsBatch).toHaveBeenCalledTimes(2);
     expect(result.success).toBe(false);
-    expect(result.message).toContain("lote(s) 1");
+    expect(result.message).toContain("batch(es) 1");
     expect(result.data).toEqual({
       fetched: 2,
       created: 1,
@@ -283,7 +283,7 @@ describe("ImportMessageReactions", () => {
       "USECASE",
       "HISTORICAL_SYNC",
       expect.stringContaining(
-        "lote 1 falhou (mensagens referenciadas: message-orphan)",
+        "batch 1 failed (referenced messages: message-orphan)",
       ),
     );
   });


### PR DESCRIPTION
## Resumo

- `ImportUsers` e `ImportUserRoles` disparavam `guild.members.fetch()` em sequência, e a segunda chamada estourava o timeout padrão do discord.js (`Members didn't arrive in time`). O fetcher agora cacheia a promise da busca de membros e a reaproveita entre os dois use cases.
- `walkMessagesInRange` abortava a importação **inteira** de mensagens/reações quando o bot não tinha acesso a um único canal (`Missing Access`, código 50001). Agora esse canal é pulado individualmente, com log de aviso, e a varredura continua nos demais canais.
- `ImportMessages` e `ImportMessageReactions` abortavam o loop inteiro no primeiro lote que falhasse ao salvar — mesmo quando o fetch já tinha avançado o cursor com sucesso. Isso é particularmente sensível no caso de reações, que dependem das mensagens já terem sido persistidas antes (`saveMessageReactionsBatch` rejeita reações órfãs via checagem de FK, ver commit 4943ddd). Agora a falha de salvamento é isolada por lote: loga o número do lote e as entradas que falharam (platformId das mensagens, ou messageId das reações), soma em `failed` e segue para os próximos lotes. Erros de fetch continuam abortando o use case, já que nesse caso não há cursor válido para continuar.

## Validação

- `npm run sync:history` (janela padrão de 3 meses) rodou sem erros, com `ImportUserRoles` e `ImportMessages`/`ImportMessageReactions` completando com sucesso.
- Testado com janela de 1 ano (`--start=2025-08-05`): sem timeouts, sem abortos, ~75s de execução.
- Testado com uma segunda janela distinta (`--start=2025-01-01 --end=2025-06-30`): também sem erros —  `Usuários: fetched=35 created=35` · `Cargos: fetched=38 created=38` · `Canais: fetched=71 created=71` · `Mensagens: fetched=55 created=55` · `Reações: fetched=1 created=1`. Nenhum dos runs reais exercitou o caminho de isolamento por lote (nenhuma escrita falhou no ambiente saudável de teste); esse comportamento está coberto pelos 2 testes unitários adicionados, que simulam a falha de propósito.
- Logs completos compartilhados internamente com a equipe (fora do controle de versão, seguindo o padrão já adotado no repo).
- `tsc --noEmit` sem erros.
- Suíte de testes: 250 passando, incluindo 2 novos testes cobrindo o isolamento de falha por lote em `ImportMessages` e `ImportMessageReactions` (as falhas em `message/repository.test.ts` e `channel/repository.test.ts` são pré-existentes, dependem de banco de dados, não relacionadas a esta mudança).

## Test plan
- [x] `npm run sync:history` sem parâmetros — conclui sem erros
- [x] `npm run sync:history -- --start=<1 ano atrás>` — conclui sem timeout/abort
- [x] `npm run sync:history -- --start=2025-01-01 --end=2025-06-30` — conclui sem erros
- [x] `npx tsc --noEmit`
- [x] `npx jest` (suíte completa, exceto falhas pré-existentes de integração com banco)
- [x] Novos testes: lote de mensagens/reações que falha ao salvar é logado e não bloqueia os lotes seguintes