### PR TITLE
CPDD-84: Ajuste para puxar reações

### DIFF
--- a/src/infrastructure/discord/fetchers/DiscordHistoryFetcher.ts
+++ b/src/infrastructure/discord/fetchers/DiscordHistoryFetcher.ts
@@ -35,6 +35,10 @@ import {
 
 const MAX_PAGE_SIZE = 100;
 const MISSING_ACCESS_ERROR_CODE = 50001;
+const RETRYABLE_ERROR_PATTERN =
+  /other side closed|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up/i;
+const MAX_RETRY_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 500;
 
 export class DiscordHistoryFetcher implements IDiscordHistoryFetcher {
   private guildMembersPromise?: Promise<{
@@ -100,7 +104,9 @@ export class DiscordHistoryFetcher implements IDiscordHistoryFetcher {
             reaction.emoji.name ??
             reaction.emoji.id ??
             "";
-          const reactedUsers = await reaction.users.fetch();
+          const reactedUsers = await this.withRetry(() =>
+            reaction.users.fetch(),
+          );
 
           for (const user of reactedUsers.values()) {
             if (user.bot) {
@@ -265,10 +271,12 @@ export class DiscordHistoryFetcher implements IDiscordHistoryFetcher {
       const channel = channels[channelIndex];
       let page: Collection<string, Message>;
       try {
-        page = await channel.messages.fetch({
-          limit: MAX_PAGE_SIZE,
-          ...(before ? { before } : {}),
-        });
+        page = await this.withRetry(() =>
+          channel.messages.fetch({
+            limit: MAX_PAGE_SIZE,
+            ...(before ? { before } : {}),
+          }),
+        );
       } catch (error) {
         if (this.isMissingAccessError(error)) {
           this.logger?.logToConsole(
@@ -327,6 +335,37 @@ export class DiscordHistoryFetcher implements IDiscordHistoryFetcher {
       "code" in error &&
       (error as { code: unknown }).code === MISSING_ACCESS_ERROR_CODE
     );
+  }
+
+  private isRetryableError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return RETRYABLE_ERROR_PATTERN.test(message);
+  }
+
+  private async withRetry<T>(operation: () => Promise<T>): Promise<T> {
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt += 1) {
+      try {
+        return await operation();
+      } catch (error) {
+        lastError = error;
+        if (!this.isRetryableError(error) || attempt === MAX_RETRY_ATTEMPTS) {
+          throw error;
+        }
+
+        const delayMs = RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+        this.logger?.logToConsole(
+          LoggerContextStatus.ERROR,
+          LoggerContext.USECASE,
+          LoggerContextEntity.HISTORICAL_SYNC,
+          `DiscordHistoryFetcher.withRetry | attempt ${attempt} failed (${error instanceof Error ? error.message : String(error)}), retrying in ${delayMs}ms`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+
+    throw lastError;
   }
 
   private listTextChannels(guild: Guild): TextChannel[] {

--- a/src/tests/discord/fetchers/DiscordHistoryFetcher.test.ts
+++ b/src/tests/discord/fetchers/DiscordHistoryFetcher.test.ts
@@ -245,6 +245,139 @@ describe("DiscordHistoryFetcher", () => {
     });
   });
 
+  describe("fetchNextMessageReactionsBatch retry behavior", () => {
+    let setTimeoutSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(((
+        fn: () => void,
+      ) => {
+        fn();
+        return 0 as unknown as NodeJS.Timeout;
+      }) as unknown as typeof setTimeout);
+    });
+
+    afterEach(() => {
+      setTimeoutSpy.mockRestore();
+    });
+
+    function createReactingUser(id: string, bot = false) {
+      return {
+        id,
+        username: `user-${id}`,
+        globalName: null,
+        bot,
+        createdTimestamp: undefined,
+      };
+    }
+
+    function createMessageWithReaction(
+      id: string,
+      timestamp: number,
+      usersFetch: jest.Mock,
+    ) {
+      return {
+        id,
+        createdTimestamp: timestamp,
+        author: {
+          id: "author-1",
+          username: "author",
+          globalName: null,
+          bot: false,
+          createdTimestamp: timestamp,
+        },
+        member: null,
+        reactions: {
+          cache: new Map([
+            [
+              "reaction-1",
+              {
+                emoji: { identifier: "👍", name: "👍", id: null },
+                users: { fetch: usersFetch },
+              },
+            ],
+          ]),
+        },
+      };
+    }
+
+    it("should retry a transient error when fetching reaction users and eventually succeed", async () => {
+      const usersFetch = jest
+        .fn()
+        .mockRejectedValueOnce(new Error("other side closed"))
+        .mockResolvedValueOnce(
+          new Map([["user-1", createReactingUser("user-1")]]),
+        );
+      const message = createMessageWithReaction(
+        "msg-1",
+        new Date("2024-01-20").getTime(),
+        usersFetch,
+      );
+      const channel = createTextChannel("channel-1", [message]);
+      const guild = createMockGuild([channel]);
+      const client = createMockClient(guild);
+      const fetcher = new DiscordHistoryFetcher(client);
+
+      const result = await fetcher.fetchNextMessageReactionsBatch({
+        startDate: new Date("2024-01-01"),
+        endDate: new Date("2024-02-01"),
+        batchSize: 100,
+      });
+
+      expect(usersFetch).toHaveBeenCalledTimes(2);
+      expect(result.reactions).toHaveLength(1);
+      expect(result.reactions[0]).toMatchObject({
+        messageId: "msg-1",
+        userId: "user-1",
+        reactionEmoji: "👍",
+      });
+    });
+
+    it("should not retry a non-transient error when fetching reaction users", async () => {
+      const usersFetch = jest.fn().mockRejectedValue(new Error("boom"));
+      const message = createMessageWithReaction(
+        "msg-1",
+        new Date("2024-01-20").getTime(),
+        usersFetch,
+      );
+      const channel = createTextChannel("channel-1", [message]);
+      const guild = createMockGuild([channel]);
+      const client = createMockClient(guild);
+      const fetcher = new DiscordHistoryFetcher(client);
+
+      await expect(
+        fetcher.fetchNextMessageReactionsBatch({
+          startDate: new Date("2024-01-01"),
+          endDate: new Date("2024-02-01"),
+          batchSize: 100,
+        }),
+      ).rejects.toThrow("boom");
+      expect(usersFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should give up after exhausting retry attempts and propagate the last transient error", async () => {
+      const usersFetch = jest.fn().mockRejectedValue(new Error("ECONNRESET"));
+      const message = createMessageWithReaction(
+        "msg-1",
+        new Date("2024-01-20").getTime(),
+        usersFetch,
+      );
+      const channel = createTextChannel("channel-1", [message]);
+      const guild = createMockGuild([channel]);
+      const client = createMockClient(guild);
+      const fetcher = new DiscordHistoryFetcher(client);
+
+      await expect(
+        fetcher.fetchNextMessageReactionsBatch({
+          startDate: new Date("2024-01-01"),
+          endDate: new Date("2024-02-01"),
+          batchSize: 100,
+        }),
+      ).rejects.toThrow("ECONNRESET");
+      expect(usersFetch).toHaveBeenCalledTimes(3);
+    });
+  });
+
   describe("fetchAudioEventsInRange", () => {
     function createMockScheduledEvent(overrides: Record<string, unknown> = {}) {
       return {


### PR DESCRIPTION
## Summary
- A etapa de reações do backfill histórico falhava com "other side closed" porque reaction.users.fetch() é chamado uma vez por (mensagem, emoji) — milhares de chamadas REST seriais — e um único erro transitório de rede abortava a etapa inteira sem retry.
- Adiciona um withRetry local (3 tentativas, backoff exponencial curto) em DiscordHistoryFetcher, aplicado a channel.messages.fetch() e reaction.users.fetch(). Só retenta erros transitórios (other side closed, ECONNRESET, ETIMEDOUT, ECONNREFUSED, socket hang up).
- Não altera ImportMessageReactions, SyncHistoryRange nem o schema — as escritas já são idempotentes, reexecutar qualquer janela continua seguro.

## Test plan
- [x] tsc --noEmit sem erros
- [x] npm run build gera dist/ com o retry presente
- [x] eslint sem avisos
- [ ] npm test (DiscordHistoryFetcher.test.ts) 
- [ ] Rodar o backfill nas janelas restantes e confirmar que reações não abortam mais