### PR TITLE
feat: adiciona PoC de análise com Metabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,20 @@
 TOKEN_BOT=
 
 # Onde o aplicativo node roda.
-PORT=3001
+PORT=3000
+
+# Porta local da PoC de análise de dados (profile analytics).
+METABASE_PORT=3001
+
+# Credenciais exclusivamente locais da PoC. Troque fora do ambiente local.
+ANALYTICS_READER_PASSWORD=analytics_local_only
+METABASE_APP_DB_PASSWORD=metabase_local_only
+METABASE_ADMIN_EMAIL=admin@checkin.local
+METABASE_ADMIN_PASSWORD=CheckinLocal123!
+METABASE_EDITOR_EMAIL=editora@checkin.local
+METABASE_EDITOR_PASSWORD=CheckinLocal123!
+METABASE_VIEWER_EMAIL=leitora@checkin.local
+METABASE_VIEWER_PASSWORD=CheckinLocal123!
 
 # Host do banco de dados (nome do serviço no docker-compose)
 DB_HOST=db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## [1.1.0] - 2026-08-26
+
+### Adicionado
+
+- Documentação do Spike com comparação entre Metabase, Apache Superset e Grafana.
+- ADR propondo o Metabase Open Source como ferramenta de análise do Check-In.
+- Profile Docker Compose `analytics` com banco analítico simulado, views agregadas e painel Metabase reproduzível.
+- Dataset de demonstração sem nomes, e-mails, identificadores pessoais ou conteúdo de mensagens.
+- Usuário de leitura do BI limitado a `SELECT` nas views analíticas.
+- Contas locais de administração, curadoria e leitura, com permissões de coleção verificadas na PoC.
+
+### Validado
+
+- Build, lint e suíte completa de testes automatizados.
+- Subida limpa da PoC em ambiente isolado.
+- Acesso ao painel, filtros por período e canal e retorno de dados nas consultas.
+- Bloqueio de escrita do usuário analítico e separação entre edição e visualização.

--- a/analytics/database/bootstrap.sh
+++ b/analytics/database/bootstrap.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+set -eu
+
+validate_local_password() {
+  value="$1"
+  name="$2"
+
+  case "$value" in
+    *[!A-Za-z0-9_.-]*)
+      echo "$name deve usar apenas letras, números, ponto, sublinhado ou hífen." >&2
+      exit 1
+      ;;
+  esac
+}
+
+validate_local_password "$ANALYTICS_READER_PASSWORD" "ANALYTICS_READER_PASSWORD"
+validate_local_password "$METABASE_APP_DB_PASSWORD" "METABASE_APP_DB_PASSWORD"
+
+mariadb --host=db --user=root --password="$DB_PASSWORD" <<SQL
+CREATE DATABASE IF NOT EXISTS \`checkindb_analytics_poc\`
+  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE DATABASE IF NOT EXISTS \`metabase_poc\`
+  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE USER IF NOT EXISTS 'metabase_app'@'%' IDENTIFIED BY '${METABASE_APP_DB_PASSWORD}';
+ALTER USER 'metabase_app'@'%' IDENTIFIED BY '${METABASE_APP_DB_PASSWORD}';
+GRANT ALL PRIVILEGES ON \`metabase_poc\`.* TO 'metabase_app'@'%';
+
+CREATE USER IF NOT EXISTS 'analytics_reader'@'%' IDENTIFIED BY '${ANALYTICS_READER_PASSWORD}';
+ALTER USER 'analytics_reader'@'%' IDENTIFIED BY '${ANALYTICS_READER_PASSWORD}';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'analytics_reader'@'%';
+FLUSH PRIVILEGES;
+SQL
+
+mariadb \
+  --host=db \
+  --user=root \
+  --password="$DB_PASSWORD" \
+  checkindb_analytics_poc \
+  < /analytics/database/schema-and-seed.sql
+
+mariadb --host=db --user=root --password="$DB_PASSWORD" <<SQL
+GRANT SELECT ON \`checkindb_analytics_poc\`.\`analytics_overview\` TO 'analytics_reader'@'%';
+GRANT SELECT ON \`checkindb_analytics_poc\`.\`analytics_activity_daily\` TO 'analytics_reader'@'%';
+GRANT SELECT ON \`checkindb_analytics_poc\`.\`analytics_channel_activity\` TO 'analytics_reader'@'%';
+GRANT SELECT ON \`checkindb_analytics_poc\`.\`analytics_audio_activity\` TO 'analytics_reader'@'%';
+GRANT SELECT ON \`checkindb_analytics_poc\`.\`analytics_retention_cohort\` TO 'analytics_reader'@'%';
+GRANT SELECT ON \`checkindb_analytics_poc\`.\`analytics_data_quality\` TO 'analytics_reader'@'%';
+FLUSH PRIVILEGES;
+SQL
+
+if mariadb \
+  --host=db \
+  --user=analytics_reader \
+  --password="$ANALYTICS_READER_PASSWORD" \
+  --execute="UPDATE checkindb_analytics_poc.user SET status = status WHERE 1 = 0" \
+  >/dev/null 2>&1; then
+  echo "O usuário analytics_reader recebeu permissão de escrita indevida." >&2
+  exit 1
+fi
+
+mariadb \
+  --host=db \
+  --user=analytics_reader \
+  --password="$ANALYTICS_READER_PASSWORD" \
+  --execute="SELECT total_members FROM checkindb_analytics_poc.analytics_overview" \
+  >/dev/null
+
+echo "Banco analítico simulado e views somente leitura preparados."

--- a/analytics/database/schema-and-seed.sql
+++ b/analytics/database/schema-and-seed.sql
@@ -1,0 +1,495 @@
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+DROP VIEW IF EXISTS analytics_data_quality;
+DROP VIEW IF EXISTS analytics_retention_cohort;
+DROP VIEW IF EXISTS analytics_audio_activity;
+DROP VIEW IF EXISTS analytics_channel_activity;
+DROP VIEW IF EXISTS analytics_activity_daily;
+DROP VIEW IF EXISTS analytics_overview;
+
+DROP TABLE IF EXISTS UserRole;
+DROP TABLE IF EXISTS UserChannel;
+DROP TABLE IF EXISTS message_reaction;
+DROP TABLE IF EXISTS user_event;
+DROP TABLE IF EXISTS audio_event;
+DROP TABLE IF EXISTS message;
+DROP TABLE IF EXISTS role;
+DROP TABLE IF EXISTS event_status;
+DROP TABLE IF EXISTS channel;
+DROP TABLE IF EXISTS user;
+
+CREATE TABLE user (
+  id INT NOT NULL AUTO_INCREMENT,
+  username VARCHAR(191) NOT NULL,
+  global_name VARCHAR(191) NULL,
+  joined_at DATETIME(3) NULL,
+  update_at DATETIME(3) NULL,
+  last_active DATETIME(3) NULL,
+  create_at DATETIME(3) NULL DEFAULT CURRENT_TIMESTAMP(3),
+  bot BOOLEAN NOT NULL,
+  email VARCHAR(191) NULL,
+  status INT NOT NULL,
+  platform_created_at DATETIME(3) NULL,
+  platform_id VARCHAR(191) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY user_platform_id_key (platform_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE channel (
+  id INT NOT NULL AUTO_INCREMENT,
+  name VARCHAR(191) NOT NULL,
+  url VARCHAR(191) NOT NULL,
+  created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  platform_id VARCHAR(191) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY channel_platform_id_key (platform_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE role (
+  id INT NOT NULL AUTO_INCREMENT,
+  name VARCHAR(191) NOT NULL,
+  created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  platform_created_at DATETIME(3) NOT NULL,
+  platform_id VARCHAR(191) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY role_platform_id_key (platform_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE event_status (
+  id INT NOT NULL AUTO_INCREMENT,
+  name VARCHAR(191) NOT NULL,
+  created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  platform_id VARCHAR(191) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY event_status_platform_id_key (platform_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE message (
+  id INT NOT NULL AUTO_INCREMENT,
+  channel_id VARCHAR(191) NOT NULL,
+  user_id VARCHAR(191) NOT NULL,
+  created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  is_deleted BOOLEAN NOT NULL DEFAULT false,
+  platform_created_at DATETIME(3) NOT NULL,
+  platform_id VARCHAR(191) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY message_platform_id_key (platform_id),
+  KEY message_channel_id_fkey (channel_id),
+  KEY message_user_id_fkey (user_id),
+  CONSTRAINT message_channel_id_fkey FOREIGN KEY (channel_id) REFERENCES channel(platform_id),
+  CONSTRAINT message_user_id_fkey FOREIGN KEY (user_id) REFERENCES user(platform_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE audio_event (
+  id INT NOT NULL AUTO_INCREMENT,
+  channel_id VARCHAR(191) NOT NULL,
+  creator_id VARCHAR(191) NOT NULL,
+  name VARCHAR(191) NOT NULL,
+  description VARCHAR(191) NULL,
+  status_id VARCHAR(191) NOT NULL,
+  start_at DATETIME(3) NOT NULL,
+  end_at DATETIME(3) NULL,
+  user_count INT NOT NULL,
+  image VARCHAR(191) NULL,
+  created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  platform_id VARCHAR(191) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY audio_event_platform_id_key (platform_id),
+  KEY audio_event_channel_id_fkey (channel_id),
+  KEY audio_event_creator_id_fkey (creator_id),
+  KEY audio_event_status_id_fkey (status_id),
+  CONSTRAINT audio_event_channel_id_fkey FOREIGN KEY (channel_id) REFERENCES channel(platform_id),
+  CONSTRAINT audio_event_creator_id_fkey FOREIGN KEY (creator_id) REFERENCES user(platform_id),
+  CONSTRAINT audio_event_status_id_fkey FOREIGN KEY (status_id) REFERENCES event_status(platform_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE user_event (
+  id INT NOT NULL AUTO_INCREMENT,
+  event_id VARCHAR(191) NOT NULL,
+  user_id VARCHAR(191) NOT NULL,
+  event_type ENUM('JOINED', 'LEFT') NOT NULL,
+  created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (id),
+  KEY user_event_event_id_fkey (event_id),
+  KEY user_event_user_id_fkey (user_id),
+  CONSTRAINT user_event_event_id_fkey FOREIGN KEY (event_id) REFERENCES audio_event(platform_id),
+  CONSTRAINT user_event_user_id_fkey FOREIGN KEY (user_id) REFERENCES user(platform_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE message_reaction (
+  user_id VARCHAR(191) NOT NULL,
+  message_id VARCHAR(191) NOT NULL,
+  channel_id VARCHAR(191) NOT NULL,
+  id INT NOT NULL AUTO_INCREMENT,
+  reaction_emoji VARCHAR(191) NULL DEFAULT '',
+  reacted_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (id),
+  UNIQUE KEY message_reaction_user_message_emoji_key (user_id, message_id, reaction_emoji),
+  KEY message_reaction_channel_id_fkey (channel_id),
+  KEY message_reaction_message_id_fkey (message_id),
+  CONSTRAINT message_reaction_channel_id_fkey FOREIGN KEY (channel_id) REFERENCES channel(platform_id),
+  CONSTRAINT message_reaction_message_id_fkey FOREIGN KEY (message_id) REFERENCES message(platform_id),
+  CONSTRAINT message_reaction_user_id_fkey FOREIGN KEY (user_id) REFERENCES user(platform_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE UserChannel (
+  user_platform_id VARCHAR(191) NOT NULL,
+  channel_platform_id VARCHAR(191) NOT NULL,
+  PRIMARY KEY (user_platform_id, channel_platform_id),
+  CONSTRAINT UserChannel_user_platform_id_fkey FOREIGN KEY (user_platform_id) REFERENCES user(platform_id),
+  CONSTRAINT UserChannel_channel_platform_id_fkey FOREIGN KEY (channel_platform_id) REFERENCES channel(platform_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE UserRole (
+  user_platform_id VARCHAR(191) NOT NULL,
+  role_platform_id VARCHAR(191) NOT NULL,
+  PRIMARY KEY (user_platform_id, role_platform_id),
+  CONSTRAINT UserRole_user_platform_id_fkey FOREIGN KEY (user_platform_id) REFERENCES user(platform_id),
+  CONSTRAINT UserRole_role_platform_id_fkey FOREIGN KEY (role_platform_id) REFERENCES role(platform_id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+DELIMITER //
+
+CREATE PROCEDURE seed_checkin_analytics_poc()
+BEGIN
+  DECLARE i INT DEFAULT 1;
+  DECLARE selected_user INT;
+  DECLARE selected_channel INT;
+  DECLARE selected_message INT;
+  DECLARE activity_time DATETIME;
+
+  INSERT INTO channel (name, url, platform_id) VALUES
+    ('acolhimento', 'https://discord.local/channels/acolhimento', 'poc-channel-01'),
+    ('formacao', 'https://discord.local/channels/formacao', 'poc-channel-02'),
+    ('projetos', 'https://discord.local/channels/projetos', 'poc-channel-03'),
+    ('convivencia', 'https://discord.local/channels/convivencia', 'poc-channel-04');
+
+  INSERT INTO event_status (name, platform_id) VALUES
+    ('Concluído', 'poc-status-completed');
+
+  INSERT INTO role (name, platform_created_at, platform_id) VALUES
+    ('Pessoa participante', DATE_SUB(CURRENT_DATE, INTERVAL 2 YEAR), 'poc-role-01'),
+    ('Pessoa facilitadora', DATE_SUB(CURRENT_DATE, INTERVAL 2 YEAR), 'poc-role-02'),
+    ('Pessoa contribuidora', DATE_SUB(CURRENT_DATE, INTERVAL 2 YEAR), 'poc-role-03');
+
+  WHILE i <= 30 DO
+    INSERT INTO user (
+      username,
+      global_name,
+      joined_at,
+      last_active,
+      bot,
+      email,
+      status,
+      platform_created_at,
+      platform_id
+    ) VALUES (
+      CONCAT('pessoa-simulada-', LPAD(i, 2, '0')),
+      CONCAT('Pessoa simulada ', LPAD(i, 2, '0')),
+      DATE_SUB(CURRENT_DATE, INTERVAL (125 - (i * 4)) DAY),
+      DATE_SUB(CURRENT_DATE, INTERVAL MOD(i * 3, 40) DAY),
+      i = 30,
+      NULL,
+      IF(i MOD 10 = 0, 0, 1),
+      DATE_SUB(CURRENT_DATE, INTERVAL (500 + i) DAY),
+      CONCAT('poc-user-', LPAD(i, 2, '0'))
+    );
+
+    IF i <= 29 THEN
+      INSERT INTO UserRole (user_platform_id, role_platform_id)
+      VALUES (
+        CONCAT('poc-user-', LPAD(i, 2, '0')),
+        CONCAT('poc-role-0', 1 + MOD(i, 3))
+      );
+
+      INSERT INTO UserChannel (user_platform_id, channel_platform_id)
+      VALUES (
+        CONCAT('poc-user-', LPAD(i, 2, '0')),
+        CONCAT('poc-channel-0', 1 + MOD(i, 4))
+      );
+    END IF;
+
+    SET i = i + 1;
+  END WHILE;
+
+  SET i = 1;
+  WHILE i <= 180 DO
+    SET selected_user = 1 + MOD(i * 7, 29);
+    SET selected_channel = 1 + MOD(i * 5, 4);
+    SET activity_time = DATE_ADD(
+      DATE_SUB(CURRENT_DATE, INTERVAL MOD(i * 11, 90) DAY),
+      INTERVAL MOD(i * 3, 24) HOUR
+    );
+
+    INSERT INTO message (
+      channel_id,
+      user_id,
+      created_at,
+      is_deleted,
+      platform_created_at,
+      platform_id
+    ) VALUES (
+      CONCAT('poc-channel-0', selected_channel),
+      CONCAT('poc-user-', LPAD(selected_user, 2, '0')),
+      activity_time,
+      i MOD 37 = 0,
+      activity_time,
+      CONCAT('poc-message-', LPAD(i, 3, '0'))
+    );
+
+    SET i = i + 1;
+  END WHILE;
+
+  SET i = 1;
+  WHILE i <= 90 DO
+    SET selected_user = 1 + MOD(i * 11, 29);
+    SET selected_message = 1 + MOD(i * 13, 180);
+    SET selected_channel = 1 + MOD(selected_message * 5, 4);
+    SET activity_time = DATE_ADD(
+      DATE_SUB(CURRENT_DATE, INTERVAL MOD(selected_message * 11, 90) DAY),
+      INTERVAL MOD(selected_message * 3 + 1, 24) HOUR
+    );
+
+    INSERT INTO message_reaction (
+      user_id,
+      message_id,
+      channel_id,
+      reaction_emoji,
+      reacted_at
+    ) VALUES (
+      CONCAT('poc-user-', LPAD(selected_user, 2, '0')),
+      CONCAT('poc-message-', LPAD(selected_message, 3, '0')),
+      CONCAT('poc-channel-0', selected_channel),
+      CASE MOD(i, 3) WHEN 0 THEN '❤️' WHEN 1 THEN '👍' ELSE '🌱' END,
+      activity_time
+    );
+
+    SET i = i + 1;
+  END WHILE;
+
+  SET i = 1;
+  WHILE i <= 6 DO
+    SET selected_user = 1 + MOD(i * 3, 29);
+    SET selected_channel = 1 + MOD(i, 4);
+    SET activity_time = DATE_ADD(
+      DATE_SUB(CURRENT_DATE, INTERVAL (i * 12) DAY),
+      INTERVAL 19 HOUR
+    );
+
+    INSERT INTO audio_event (
+      channel_id,
+      creator_id,
+      name,
+      description,
+      status_id,
+      start_at,
+      end_at,
+      user_count,
+      image,
+      created_at,
+      platform_id
+    ) VALUES (
+      CONCAT('poc-channel-0', selected_channel),
+      CONCAT('poc-user-', LPAD(selected_user, 2, '0')),
+      CONCAT('Encontro simulado ', LPAD(i, 2, '0')),
+      'Evento criado apenas para a prova de conceito',
+      'poc-status-completed',
+      activity_time,
+      DATE_ADD(activity_time, INTERVAL (45 + i * 5) MINUTE),
+      5,
+      NULL,
+      activity_time,
+      CONCAT('poc-audio-', LPAD(i, 2, '0'))
+    );
+
+    SET selected_message = 1;
+    WHILE selected_message <= 5 DO
+      SET selected_user = 1 + MOD(i * 5 + selected_message * 3, 29);
+
+      INSERT INTO user_event (event_id, user_id, event_type, created_at) VALUES
+        (
+          CONCAT('poc-audio-', LPAD(i, 2, '0')),
+          CONCAT('poc-user-', LPAD(selected_user, 2, '0')),
+          'JOINED',
+          DATE_ADD(activity_time, INTERVAL selected_message MINUTE)
+        ),
+        (
+          CONCAT('poc-audio-', LPAD(i, 2, '0')),
+          CONCAT('poc-user-', LPAD(selected_user, 2, '0')),
+          'LEFT',
+          DATE_ADD(activity_time, INTERVAL (35 + selected_message * 3) MINUTE)
+        );
+
+      SET selected_message = selected_message + 1;
+    END WHILE;
+
+    SET i = i + 1;
+  END WHILE;
+END//
+
+DELIMITER ;
+
+CALL seed_checkin_analytics_poc();
+DROP PROCEDURE seed_checkin_analytics_poc;
+
+CREATE VIEW analytics_overview AS
+SELECT
+  (SELECT COUNT(*) FROM user WHERE bot = false) AS total_members,
+  (SELECT COUNT(*) FROM channel) AS total_channels,
+  (SELECT COUNT(*) FROM message WHERE is_deleted = false) AS total_messages,
+  (SELECT COUNT(*) FROM message_reaction) AS total_reactions,
+  (SELECT COUNT(*) FROM audio_event) AS total_audio_events,
+  (SELECT COUNT(*) FROM user_event) AS total_voice_movements;
+
+CREATE VIEW analytics_activity_daily AS
+SELECT
+  activity.activity_date,
+  SUM(activity.messages) AS messages,
+  SUM(activity.reactions) AS reactions,
+  SUM(activity.voice_joins) AS voice_joins,
+  COUNT(DISTINCT activity.user_id) AS active_members
+FROM (
+  SELECT
+    DATE(m.platform_created_at) AS activity_date,
+    m.user_id,
+    COUNT(*) AS messages,
+    0 AS reactions,
+    0 AS voice_joins
+  FROM message m
+  INNER JOIN user u ON u.platform_id = m.user_id AND u.bot = false
+  WHERE m.is_deleted = false
+  GROUP BY DATE(m.platform_created_at), m.user_id
+
+  UNION ALL
+
+  SELECT
+    DATE(mr.reacted_at) AS activity_date,
+    mr.user_id,
+    0 AS messages,
+    COUNT(*) AS reactions,
+    0 AS voice_joins
+  FROM message_reaction mr
+  INNER JOIN user u ON u.platform_id = mr.user_id AND u.bot = false
+  GROUP BY DATE(mr.reacted_at), mr.user_id
+
+  UNION ALL
+
+  SELECT
+    DATE(ue.created_at) AS activity_date,
+    ue.user_id,
+    0 AS messages,
+    0 AS reactions,
+    COUNT(*) AS voice_joins
+  FROM user_event ue
+  INNER JOIN user u ON u.platform_id = ue.user_id AND u.bot = false
+  WHERE ue.event_type = 'JOINED'
+  GROUP BY DATE(ue.created_at), ue.user_id
+) activity
+GROUP BY activity.activity_date;
+
+CREATE VIEW analytics_channel_activity AS
+SELECT
+  c.name AS channel_name,
+  COALESCE(messages.message_count, 0) AS messages,
+  COALESCE(messages.active_members, 0) AS active_members,
+  COALESCE(reactions.reaction_count, 0) AS reactions,
+  COALESCE(audio.audio_event_count, 0) AS audio_events
+FROM channel c
+LEFT JOIN (
+  SELECT
+    channel_id,
+    COUNT(*) AS message_count,
+    COUNT(DISTINCT user_id) AS active_members
+  FROM message
+  WHERE is_deleted = false
+  GROUP BY channel_id
+) messages ON messages.channel_id = c.platform_id
+LEFT JOIN (
+  SELECT channel_id, COUNT(*) AS reaction_count
+  FROM message_reaction
+  GROUP BY channel_id
+) reactions ON reactions.channel_id = c.platform_id
+LEFT JOIN (
+  SELECT channel_id, COUNT(*) AS audio_event_count
+  FROM audio_event
+  GROUP BY channel_id
+) audio ON audio.channel_id = c.platform_id;
+
+CREATE VIEW analytics_audio_activity AS
+SELECT
+  DATE(ae.start_at) AS event_date,
+  c.name AS channel_name,
+  COUNT(*) AS audio_events,
+  SUM(ae.user_count) AS declared_participants,
+  SUM(TIMESTAMPDIFF(MINUTE, ae.start_at, ae.end_at)) AS total_minutes
+FROM audio_event ae
+INNER JOIN channel c ON c.platform_id = ae.channel_id
+GROUP BY DATE(ae.start_at), c.name;
+
+CREATE VIEW analytics_retention_cohort AS
+SELECT
+  DATE_FORMAT(u.joined_at, '%Y-%m-01') AS cohort_month,
+  DATE_FORMAT(activity.activity_date, '%Y-%m-01') AS activity_month,
+  COUNT(DISTINCT u.platform_id) AS retained_members,
+  cohort.cohort_size,
+  ROUND(COUNT(DISTINCT u.platform_id) * 100.0 / cohort.cohort_size, 1) AS retention_rate
+FROM user u
+INNER JOIN (
+  SELECT DATE(platform_created_at) AS activity_date, user_id
+  FROM message
+  WHERE is_deleted = false
+  UNION
+  SELECT DATE(reacted_at) AS activity_date, user_id
+  FROM message_reaction
+  UNION
+  SELECT DATE(created_at) AS activity_date, user_id
+  FROM user_event
+  WHERE event_type = 'JOINED'
+) activity ON activity.user_id = u.platform_id
+INNER JOIN (
+  SELECT DATE_FORMAT(joined_at, '%Y-%m-01') AS cohort_month, COUNT(*) AS cohort_size
+  FROM user
+  WHERE bot = false
+  GROUP BY DATE_FORMAT(joined_at, '%Y-%m-01')
+) cohort ON cohort.cohort_month = DATE_FORMAT(u.joined_at, '%Y-%m-01')
+WHERE u.bot = false AND activity.activity_date >= DATE(u.joined_at)
+GROUP BY
+  DATE_FORMAT(u.joined_at, '%Y-%m-01'),
+  DATE_FORMAT(activity.activity_date, '%Y-%m-01'),
+  cohort.cohort_size;
+
+CREATE VIEW analytics_data_quality AS
+SELECT
+  'messages' AS source_name,
+  COUNT(*) AS row_count,
+  MIN(DATE(platform_created_at)) AS coverage_start,
+  MAX(DATE(platform_created_at)) AS coverage_end,
+  'Data original da plataforma; mensagens excluídas não entram nas métricas.' AS caveat
+FROM message
+UNION ALL
+SELECT
+  'reactions',
+  COUNT(*),
+  MIN(DATE(reacted_at)),
+  MAX(DATE(reacted_at)),
+  'Em backfills reais, o horário da reação pode ser aproximado.'
+FROM message_reaction
+UNION ALL
+SELECT
+  'audio_events',
+  COUNT(*),
+  MIN(DATE(start_at)),
+  MAX(DATE(start_at)),
+  'Eventos históricos podem ter cobertura incompleta.'
+FROM audio_event
+UNION ALL
+SELECT
+  'voice_movements',
+  COUNT(*),
+  MIN(DATE(created_at)),
+  MAX(DATE(created_at)),
+  'Entradas e saídas históricas podem não ser recuperáveis.'
+FROM user_event;

--- a/analytics/metabase/bootstrap.mjs
+++ b/analytics/metabase/bootstrap.mjs
@@ -1,0 +1,667 @@
+const baseUrl = process.env.METABASE_URL ?? "http://metabase:3000";
+const adminEmail = process.env.METABASE_ADMIN_EMAIL;
+const adminPassword = process.env.METABASE_ADMIN_PASSWORD;
+const editorEmail = process.env.METABASE_EDITOR_EMAIL;
+const editorPassword = process.env.METABASE_EDITOR_PASSWORD;
+const viewerEmail = process.env.METABASE_VIEWER_EMAIL;
+const viewerPassword = process.env.METABASE_VIEWER_PASSWORD;
+const analyticsReaderPassword = process.env.ANALYTICS_READER_PASSWORD;
+
+const requiredEnvironmentVariables = {
+  METABASE_ADMIN_EMAIL: adminEmail,
+  METABASE_ADMIN_PASSWORD: adminPassword,
+  METABASE_EDITOR_EMAIL: editorEmail,
+  METABASE_EDITOR_PASSWORD: editorPassword,
+  METABASE_VIEWER_EMAIL: viewerEmail,
+  METABASE_VIEWER_PASSWORD: viewerPassword,
+  ANALYTICS_READER_PASSWORD: analyticsReaderPassword,
+};
+
+for (const [name, value] of Object.entries(requiredEnvironmentVariables)) {
+  if (!value) {
+    throw new Error(`Variável obrigatória ausente: ${name}`);
+  }
+}
+
+let sessionId;
+
+async function request(pathname, options = {}) {
+  const headers = {
+    Accept: "application/json",
+    ...(options.body ? { "Content-Type": "application/json" } : {}),
+    ...(sessionId ? { "X-Metabase-Session": sessionId } : {}),
+    ...options.headers,
+  };
+  const response = await fetch(`${baseUrl}${pathname}`, {
+    ...options,
+    headers,
+    body:
+      options.body && typeof options.body !== "string"
+        ? JSON.stringify(options.body)
+        : options.body,
+  });
+  const responseText = await response.text();
+  const responseBody = responseText
+    ? (() => {
+        try {
+          return JSON.parse(responseText);
+        } catch {
+          return responseText;
+        }
+      })()
+    : null;
+
+  if (!response.ok) {
+    throw new Error(
+      `${options.method ?? "GET"} ${pathname} retornou ${response.status}: ${JSON.stringify(responseBody)}`,
+    );
+  }
+
+  return responseBody;
+}
+
+async function waitForMetabase() {
+  for (let attempt = 1; attempt <= 60; attempt += 1) {
+    try {
+      const health = await request("/api/health");
+      if (health?.status === "ok") return;
+    } catch {
+      // O healthcheck do Compose pode encerrar antes de a rede do sidecar estabilizar.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+  throw new Error("Metabase não ficou saudável no tempo esperado.");
+}
+
+async function setupOrLogin() {
+  const properties = await request("/api/session/properties");
+  const setupToken = properties["setup-token"];
+
+  if (setupToken) {
+    await request("/api/setup", {
+      method: "POST",
+      body: {
+        token: setupToken,
+        user: {
+          email: adminEmail,
+          first_name: "Administração",
+          last_name: "Check-In",
+          password: adminPassword,
+        },
+        prefs: {
+          site_name: "Check-In — Saúde da Comunidade",
+          site_locale: "pt_BR",
+          allow_tracking: false,
+        },
+      },
+    });
+  }
+
+  const session = await request("/api/session", {
+    method: "POST",
+    body: { username: adminEmail, password: adminPassword },
+  });
+  sessionId = session.id;
+}
+
+async function findOrCreateGroup(name) {
+  const groups = await request("/api/permissions/group");
+  const existing = groups.find((group) => group.name === name);
+  if (existing) return existing;
+  return request("/api/permissions/group", {
+    method: "POST",
+    body: { name },
+  });
+}
+
+async function findOrCreateUser({ email, password, firstName, groupId }) {
+  const usersResponse = await request("/api/user?status=all");
+  const users = Array.isArray(usersResponse)
+    ? usersResponse
+    : (usersResponse.data ?? []);
+  let user = users.find((candidate) => candidate.email === email);
+  if (!user) {
+    user = await request("/api/user", {
+      method: "POST",
+      body: {
+        email,
+        first_name: firstName,
+        last_name: "Check-In",
+        password,
+      },
+    });
+  }
+
+  const memberships = await request("/api/permissions/membership");
+  const userMemberships = memberships[String(user.id)] ?? [];
+  const isMember = userMemberships.some(
+    (membership) => membership.group_id === groupId,
+  );
+  if (!isMember) {
+    await request("/api/permissions/membership", {
+      method: "POST",
+      body: { user_id: user.id, group_id: groupId },
+    });
+  }
+
+  return user;
+}
+
+async function findOrCreateDatabase() {
+  const response = await request("/api/database");
+  const databases = response.data ?? response;
+  const existing = databases.find(
+    (database) => database.name === "Check-In Analytics PoC",
+  );
+  if (existing) return existing;
+
+  return request("/api/database", {
+    method: "POST",
+    body: {
+      name: "Check-In Analytics PoC",
+      engine: "mysql",
+      is_full_sync: true,
+      is_on_demand: false,
+      auto_run_queries: false,
+      details: {
+        host: "db",
+        port: 3306,
+        db: "checkindb_analytics_poc",
+        user: "analytics_reader",
+        password: analyticsReaderPassword,
+        ssl: false,
+        "tunnel-enabled": false,
+      },
+    },
+  });
+}
+
+async function waitForAnalyticsMetadata(databaseId) {
+  await request(`/api/database/${databaseId}/sync_schema`, { method: "POST" });
+
+  const expectedViews = new Set([
+    "analytics_overview",
+    "analytics_activity_daily",
+    "analytics_channel_activity",
+    "analytics_audio_activity",
+    "analytics_retention_cohort",
+    "analytics_data_quality",
+  ]);
+
+  for (let attempt = 1; attempt <= 60; attempt += 1) {
+    const metadata = await request(`/api/database/${databaseId}/metadata`);
+    const viewNames = new Set(metadata.tables.map((table) => table.name));
+    if ([...expectedViews].every((viewName) => viewNames.has(viewName))) {
+      return metadata;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+
+  throw new Error(
+    "As views analíticas não apareceram no catálogo do Metabase.",
+  );
+}
+
+function findFieldId(metadata, tableName, fieldName) {
+  const table = metadata.tables.find(
+    (candidate) => candidate.name === tableName,
+  );
+  const field = table?.fields.find((candidate) => candidate.name === fieldName);
+  if (!field) {
+    throw new Error(`Campo analítico ausente: ${tableName}.${fieldName}`);
+  }
+  return field.id;
+}
+
+async function findOrCreateCollection() {
+  const collections = await request("/api/collection?archived=false");
+  const existing = collections.find(
+    (collection) => collection.name === "Saúde da Comunidade",
+  );
+  if (existing) return existing;
+
+  return request("/api/collection", {
+    method: "POST",
+    body: {
+      name: "Saúde da Comunidade",
+      description:
+        "Painéis agregados da PoC do Check-In, sem identificação individual.",
+      parent_id: null,
+    },
+  });
+}
+
+function fieldFilterTag(name, displayName, fieldId, widgetType) {
+  return {
+    id: name,
+    name,
+    "display-name": displayName,
+    type: "dimension",
+    dimension: ["field", fieldId, null],
+    "widget-type": widgetType,
+    required: false,
+  };
+}
+
+async function findOrUpsertCard({
+  name,
+  description,
+  display,
+  query,
+  templateTags = {},
+  visualizationSettings = {},
+  collectionId,
+  databaseId,
+}) {
+  const cards = await request("/api/card?f=all");
+  const existing = cards.find(
+    (card) => card.name === name && card.collection_id === collectionId,
+  );
+  const body = {
+    name,
+    description,
+    display,
+    collection_id: collectionId,
+    visualization_settings: visualizationSettings,
+    dataset_query: {
+      type: "native",
+      database: databaseId,
+      native: {
+        query,
+        "template-tags": templateTags,
+      },
+    },
+  };
+
+  if (existing) {
+    return request(`/api/card/${existing.id}`, { method: "PUT", body });
+  }
+  return request("/api/card", { method: "POST", body });
+}
+
+async function createCards({ databaseId, collectionId, metadata }) {
+  const periodDaily = fieldFilterTag(
+    "period",
+    "Período",
+    findFieldId(metadata, "analytics_activity_daily", "activity_date"),
+    "date/all-options",
+  );
+  const channelActivity = fieldFilterTag(
+    "channel",
+    "Canal",
+    findFieldId(metadata, "analytics_channel_activity", "channel_name"),
+    "category",
+  );
+  const periodAudio = fieldFilterTag(
+    "period",
+    "Período",
+    findFieldId(metadata, "analytics_audio_activity", "event_date"),
+    "date/all-options",
+  );
+  const channelAudio = fieldFilterTag(
+    "channel",
+    "Canal",
+    findFieldId(metadata, "analytics_audio_activity", "channel_name"),
+    "category",
+  );
+
+  const definitions = [
+    ["Membros", "total_members"],
+    ["Canais", "total_channels"],
+    ["Mensagens", "total_messages"],
+    ["Reações", "total_reactions"],
+    ["Total de eventos de voz", "total_audio_events"],
+    ["Total de movimentos em voz", "total_voice_movements"],
+  ].map(([name, column]) => ({
+    name,
+    description: "Indicador agregado do dataset simulado.",
+    display: "scalar",
+    query: `SELECT ${column} AS value FROM analytics_overview`,
+    visualizationSettings: { "scalar.field": "value" },
+  }));
+
+  definitions.push(
+    {
+      name: "Participação diária",
+      description: "Mensagens, reações e membros ativos por dia.",
+      display: "line",
+      query:
+        "SELECT activity_date, messages, reactions, voice_joins, active_members FROM analytics_activity_daily WHERE 1 = 1 [[AND {{period}}]] ORDER BY activity_date",
+      templateTags: { period: periodDaily },
+      visualizationSettings: {
+        "graph.dimensions": ["activity_date"],
+        "graph.metrics": ["messages", "reactions", "active_members"],
+      },
+    },
+    {
+      name: "Participação por canal",
+      description: "Volume agregado por canal, sem ranking de pessoas.",
+      display: "row",
+      query:
+        "SELECT channel_name, messages, reactions, active_members, audio_events FROM analytics_channel_activity WHERE 1 = 1 [[AND {{channel}}]] ORDER BY messages DESC",
+      templateTags: { channel: channelActivity },
+      visualizationSettings: {
+        "graph.dimensions": ["channel_name"],
+        "graph.metrics": ["messages", "reactions", "active_members"],
+      },
+    },
+    {
+      name: "Eventos de voz",
+      description: "Eventos, participantes declarados e duração agregada.",
+      display: "bar",
+      query:
+        "SELECT event_date, channel_name, audio_events, declared_participants, total_minutes FROM analytics_audio_activity WHERE 1 = 1 [[AND {{period}}]] [[AND {{channel}}]] ORDER BY event_date",
+      templateTags: { period: periodAudio, channel: channelAudio },
+      visualizationSettings: {
+        "graph.dimensions": ["event_date"],
+        "graph.metrics": ["declared_participants", "total_minutes"],
+      },
+    },
+    {
+      name: "Retenção por coorte",
+      description: "Retorno agregado de grupos de entrada ao longo dos meses.",
+      display: "table",
+      query:
+        "SELECT cohort_month, activity_month, cohort_size, retained_members, retention_rate FROM analytics_retention_cohort ORDER BY cohort_month, activity_month",
+    },
+    {
+      name: "Qualidade e cobertura dos dados",
+      description: "Período coberto e ressalvas de cada fonte.",
+      display: "table",
+      query:
+        "SELECT source_name, row_count, coverage_start, coverage_end, caveat FROM analytics_data_quality ORDER BY source_name",
+    },
+  );
+
+  const cards = [];
+  for (const definition of definitions) {
+    cards.push(
+      await findOrUpsertCard({
+        ...definition,
+        collectionId,
+        databaseId,
+      }),
+    );
+  }
+  return cards;
+}
+
+async function findOrCreateDashboard(collectionId) {
+  const dashboards = await request("/api/dashboard?f=all");
+  const existing = dashboards.find(
+    (dashboard) =>
+      dashboard.name === "Saúde da Comunidade" &&
+      dashboard.collection_id === collectionId,
+  );
+  if (existing) return existing;
+
+  return request("/api/dashboard", {
+    method: "POST",
+    body: {
+      name: "Saúde da Comunidade",
+      description:
+        "Leitura agregada da participação comunitária com dados simulados.",
+      collection_id: collectionId,
+      parameters: [
+        {
+          id: "period",
+          name: "Período",
+          slug: "period",
+          type: "date/range",
+        },
+        {
+          id: "channel",
+          name: "Canal",
+          slug: "channel",
+          type: "string/=",
+        },
+      ],
+    },
+  });
+}
+
+function mappingsForCard(card) {
+  const parametersByCardName = {
+    "Participação diária": ["period"],
+    "Participação por canal": ["channel"],
+    "Eventos de voz": ["period", "channel"],
+  };
+  return (parametersByCardName[card.name] ?? []).map((parameterId) => ({
+    parameter_id: parameterId,
+    card_id: card.id,
+    target: ["dimension", ["template-tag", parameterId]],
+  }));
+}
+
+async function configureDashboard(dashboard, cards) {
+  await request(`/api/dashboard/${dashboard.id}`, {
+    method: "PUT",
+    body: {
+      parameters: [
+        {
+          id: "period",
+          name: "Período",
+          slug: "period",
+          type: "date/range",
+        },
+        {
+          id: "channel",
+          name: "Canal",
+          slug: "channel",
+          type: "string/=",
+        },
+      ],
+      width: "full",
+    },
+  });
+
+  const current = await request(`/api/dashboard/${dashboard.id}`);
+  const existingByCardId = new Map(
+    (current.dashcards ?? []).map((dashcard) => [dashcard.card_id, dashcard]),
+  );
+  let nextTemporaryId = -1;
+  const dashboardCards = cards.map((card, index) => {
+    const existing = existingByCardId.get(card.id);
+    const isKpi = index < 6;
+    const position = isKpi
+      ? { row: 0, col: index * 4, size_x: 4, size_y: 3 }
+      : {
+          row: 3 + Math.floor((index - 6) / 2) * 8,
+          col: ((index - 6) % 2) * 12,
+          size_x: 12,
+          size_y: 8,
+        };
+
+    return {
+      id: existing?.id ?? nextTemporaryId--,
+      card_id: card.id,
+      ...position,
+      visualization_settings: {},
+      parameter_mappings: mappingsForCard(card),
+      series: [],
+    };
+  });
+
+  await request(`/api/dashboard/${dashboard.id}/cards`, {
+    method: "PUT",
+    body: { cards: dashboardCards },
+  });
+}
+
+async function configureCollectionPermissions(
+  collectionId,
+  editorGroup,
+  viewerGroup,
+) {
+  const response = await fetch(`${baseUrl}/api/collection/graph`, {
+    headers: { "X-Metabase-Session": sessionId },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `GET /api/collection/graph retornou ${response.status}; não foi possível validar as permissões OSS.`,
+    );
+  }
+  const graph = await response.json();
+  const groups = structuredClone(graph.groups);
+  const permissionGroups = await request("/api/permissions/group");
+  const allUsersGroup = permissionGroups.find(
+    (group) => group.magic_group_type === "all-internal-users",
+  );
+  if (!allUsersGroup) {
+    throw new Error("Grupo interno 'All Users' não encontrado.");
+  }
+  groups[String(allUsersGroup.id)] = {
+    ...(groups[String(allUsersGroup.id)] ?? { root: "write" }),
+    [String(collectionId)]: "none",
+  };
+  groups[String(editorGroup.id)] = {
+    ...(groups[String(editorGroup.id)] ?? { root: "none" }),
+    [String(collectionId)]: "write",
+  };
+  groups[String(viewerGroup.id)] = {
+    ...(groups[String(viewerGroup.id)] ?? { root: "none" }),
+    [String(collectionId)]: "read",
+  };
+
+  await request("/api/collection/graph", {
+    method: "PUT",
+    body: { revision: graph.revision, groups },
+  });
+}
+
+async function verifyCardQueries(cards) {
+  for (const card of cards) {
+    const result = await request(`/api/card/${card.id}/query`, {
+      method: "POST",
+      body: { ignore_cache: true, parameters: [] },
+    });
+    if (result.status !== "completed" || !result.data?.rows?.length) {
+      throw new Error(`A pergunta "${card.name}" não retornou dados.`);
+    }
+  }
+
+  const channelCard = cards.find(
+    (card) => card.name === "Participação por canal",
+  );
+  const filteredResult = await request(`/api/card/${channelCard.id}/query`, {
+    method: "POST",
+    body: {
+      ignore_cache: true,
+      parameters: [
+        {
+          id: "channel",
+          type: "category",
+          target: ["dimension", ["template-tag", "channel"]],
+          value: ["acolhimento"],
+        },
+      ],
+    },
+  });
+  if (
+    filteredResult.status !== "completed" ||
+    filteredResult.data?.rows?.length !== 1
+  ) {
+    throw new Error("O filtro de canal não restringiu o cartão esperado.");
+  }
+}
+
+async function loginAs(username, password) {
+  const response = await fetch(`${baseUrl}/api/session`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  if (!response.ok) {
+    throw new Error(`Falha no login de validação para ${username}.`);
+  }
+  return (await response.json()).id;
+}
+
+async function verifyRolePermissions({ dashboard, collection }) {
+  const editorSession = await loginAs(editorEmail, editorPassword);
+  const viewerSession = await loginAs(viewerEmail, viewerPassword);
+  const collectionBody = JSON.stringify({
+    description:
+      "Painéis agregados da PoC do Check-In, sem identificação individual.",
+  });
+
+  const viewerDashboard = await fetch(
+    `${baseUrl}/api/dashboard/${dashboard.id}`,
+    { headers: { "X-Metabase-Session": viewerSession } },
+  );
+  const editorUpdate = await fetch(
+    `${baseUrl}/api/collection/${collection.id}`,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Metabase-Session": editorSession,
+      },
+      body: collectionBody,
+    },
+  );
+  const viewerUpdate = await fetch(
+    `${baseUrl}/api/collection/${collection.id}`,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Metabase-Session": viewerSession,
+      },
+      body: collectionBody,
+    },
+  );
+
+  if (!viewerDashboard.ok || !editorUpdate.ok || viewerUpdate.status !== 403) {
+    throw new Error(
+      `RBAC inesperado: dashboard=${viewerDashboard.status}, editora=${editorUpdate.status}, leitora=${viewerUpdate.status}.`,
+    );
+  }
+}
+
+await waitForMetabase();
+await setupOrLogin();
+
+const editorGroup = await findOrCreateGroup("Editoras");
+const viewerGroup = await findOrCreateGroup("Leitoras");
+await findOrCreateUser({
+  email: editorEmail,
+  password: editorPassword,
+  firstName: "Pessoa editora",
+  groupId: editorGroup.id,
+});
+await findOrCreateUser({
+  email: viewerEmail,
+  password: viewerPassword,
+  firstName: "Pessoa leitora",
+  groupId: viewerGroup.id,
+});
+
+const database = await findOrCreateDatabase();
+const metadata = await waitForAnalyticsMetadata(database.id);
+const collection = await findOrCreateCollection();
+const cards = await createCards({
+  databaseId: database.id,
+  collectionId: collection.id,
+  metadata,
+});
+const dashboard = await findOrCreateDashboard(collection.id);
+await configureDashboard(dashboard, cards);
+await configureCollectionPermissions(collection.id, editorGroup, viewerGroup);
+await verifyCardQueries(cards);
+await verifyRolePermissions({ dashboard, collection });
+
+console.log(
+  JSON.stringify(
+    {
+      status: "ok",
+      database: database.name,
+      collection: collection.name,
+      dashboard: dashboard.name,
+      cards: cards.length,
+      groups: [editorGroup.name, viewerGroup.name],
+    },
+    null,
+    2,
+  ),
+);

--- a/compose.yml
+++ b/compose.yml
@@ -32,5 +32,68 @@ services:
       sh -c "npx prisma migrate deploy && npm start"
     profiles: ["dev", "homol", "prod"]
 
+  analytics-init:
+    image: mariadb:latest
+    restart: "no"
+    environment:
+      DB_PASSWORD: "${DB_PASSWORD}"
+      ANALYTICS_READER_PASSWORD: "${ANALYTICS_READER_PASSWORD:-analytics_local_only}"
+      METABASE_APP_DB_PASSWORD: "${METABASE_APP_DB_PASSWORD:-metabase_local_only}"
+    volumes:
+      - ./analytics/database:/analytics/database:ro
+    depends_on:
+      db:
+        condition: service_healthy
+    command: ["sh", "/analytics/database/bootstrap.sh"]
+    profiles: ["analytics"]
+
+  metabase:
+    image: metabase/metabase:v0.63.14
+    restart: unless-stopped
+    environment:
+      MB_DB_TYPE: mysql
+      MB_DB_DBNAME: metabase_poc
+      MB_DB_PORT: 3306
+      MB_DB_USER: metabase_app
+      MB_DB_PASS: "${METABASE_APP_DB_PASSWORD:-metabase_local_only}"
+      MB_DB_HOST: db
+      MB_LOAD_SAMPLE_CONTENT: "false"
+      MB_INSTALL_ANALYTICS_DATABASE: "false"
+      MB_LOAD_ANALYTICS_CONTENT: "false"
+      MB_ANON_TRACKING_ENABLED: "false"
+      JAVA_TIMEZONE: America/Sao_Paulo
+    ports:
+      - "127.0.0.1:${METABASE_PORT:-3001}:3000"
+    depends_on:
+      analytics-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:3000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+    profiles: ["analytics"]
+
+  metabase-bootstrap:
+    image: node:20-alpine
+    restart: "no"
+    environment:
+      METABASE_URL: http://metabase:3000
+      METABASE_ADMIN_EMAIL: "${METABASE_ADMIN_EMAIL:-admin@checkin.local}"
+      METABASE_ADMIN_PASSWORD: "${METABASE_ADMIN_PASSWORD:-CheckinLocal123!}"
+      METABASE_EDITOR_EMAIL: "${METABASE_EDITOR_EMAIL:-editora@checkin.local}"
+      METABASE_EDITOR_PASSWORD: "${METABASE_EDITOR_PASSWORD:-CheckinLocal123!}"
+      METABASE_VIEWER_EMAIL: "${METABASE_VIEWER_EMAIL:-leitora@checkin.local}"
+      METABASE_VIEWER_PASSWORD: "${METABASE_VIEWER_PASSWORD:-CheckinLocal123!}"
+      ANALYTICS_READER_PASSWORD: "${ANALYTICS_READER_PASSWORD:-analytics_local_only}"
+    volumes:
+      - ./analytics/metabase:/analytics/metabase:ro
+    depends_on:
+      metabase:
+        condition: service_healthy
+    command: ["node", "/analytics/metabase/bootstrap.mjs"]
+    profiles: ["analytics"]
+
 volumes:
   db_data:

--- a/docs/9 - Plano de implantação do Metabase.md
+++ b/docs/9 - Plano de implantação do Metabase.md
@@ -1,0 +1,285 @@
+# 🚀 Plano de implantação do Metabase
+
+**Estado:** planejado — ainda não implantado em homologação ou produção.
+
+Este documento explica como transformar a prova de conceito local do Metabase em um serviço privado para apoiar conversas sobre a saúde da comunidade. A proposta preserva o papel do Checkin Bot: coletar sinais mínimos de participação e oferecer uma leitura agregada, sem criar uma ferramenta de vigilância ou avaliação individual.
+
+## Por que existe um plano separado
+
+A PoC já demonstrou que o Metabase consegue abrir um painel, aplicar filtros e consultar views somente leitura. Porém, ela foi construída para experimentação local. O profile `analytics` atual cria o banco `checkindb_analytics_poc`, carrega dados simulados e usa credenciais padrão de demonstração.
+
+Colocar a PoC no ar sem adaptação publicaria uma demonstração, não uma solução conectada com segurança aos dados reais. A implantação precisa separar três responsabilidades:
+
+- o **banco operacional**, onde o Checkin Bot grava os metadados coletados;
+- o **banco da aplicação Metabase**, onde ficam contas, perguntas, coleções e dashboards;
+- a **camada analítica**, formada por views agregadas e uma conta de banco somente leitura.
+
+O comando local `docker compose --profile analytics up -d` continua sendo útil para testar a PoC. Ele não deve ser usado sem mudanças no servidor compartilhado.
+
+## O que significa “colocar no ar”
+
+Na primeira entrega, o Metabase será uma aplicação separada do worker do Discord. Pessoas autorizadas acessarão uma URL privada, entrarão com suas próprias contas e verão o painel “Saúde da Comunidade”.
+
+Não está planejado nesta etapa:
+
+- criar uma interface web dentro do Checkin Bot;
+- publicar o painel anonimamente;
+- expor tabelas com nomes, e-mails ou IDs de pessoas;
+- permitir alterações no banco operacional;
+- executar análises em tempo real;
+- usar o painel para pontuar, comparar ou ranquear integrantes.
+
+## Arquitetura proposta
+
+```text
+Discord Gateway
+    ↓
+Checkin Bot
+    ↓ escrita
+MariaDB operacional
+    ↓ leitura agregada
+Views analytics_*
+    ↓ SELECT com analytics_reader
+Metabase
+    ├── banco próprio da aplicação
+    └── painel “Saúde da Comunidade”
+            ↓
+    HTTPS + login de pessoas autorizadas
+```
+
+As views são a principal fronteira de segurança. O Metabase não precisa conhecer as tabelas que contêm identificadores pessoais: ele recebe apenas resultados agregados que já foram preparados para análise comunitária.
+
+## Caminho recomendado
+
+A implantação deve acontecer em duas etapas. Primeiro sobe uma homologação privada para validar dados, acesso e consumo de recursos. Produção só acontece depois dessa validação e da conversa coletiva já prevista no Spike.
+
+| Etapa                | Para que serve                                                         | Recomendação inicial                                                 |
+| -------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Homologação privada  | Confirmar segurança, funcionamento, legibilidade e impacto no servidor | Mesmo droplet, com serviço e configuração isolados                   |
+| Produção comunitária | Oferecer o painel de forma contínua para o grupo autorizado            | Servidor ou capacidade separados se houver disputa por recursos      |
+| Evolução futura      | Reduzir carga no banco operacional e permitir agregações mais custosas | Réplica somente leitura ou banco analítico atualizado periodicamente |
+
+Usar o mesmo droplet na homologação reduz o custo e acelera o aprendizado. Essa escolha não deve ser tratada como definitiva. A PoC consumiu aproximadamente `1,4 GiB` após carregar o painel; o teste no servidor precisa mostrar se esse consumo convive bem com o bot e o MariaDB.
+
+## 1. Preparar a leitura dos dados reais
+
+O arquivo `analytics/database/schema-and-seed.sql` pertence à PoC. Ele recria um schema compatível e insere dados simulados. A implantação precisa de um segundo arquivo, planejado como `analytics/database/production-views.sql`, com regras diferentes:
+
+- usar `CREATE OR REPLACE VIEW` sobre o schema operacional;
+- não executar `DROP TABLE`;
+- não inserir dados de demonstração;
+- não copiar nomes, e-mails ou IDs pessoais para a saída;
+- preferir `platform_created_at` para mensagens e outras atividades do Discord;
+- explicar cobertura incompleta de reações históricas e eventos de voz;
+- não tratar `UserRole` ou `UserChannel` como histórico temporal.
+
+As primeiras views podem manter o vocabulário validado pela PoC:
+
+| View                         | Pergunta respondida em linguagem simples                        |
+| ---------------------------- | --------------------------------------------------------------- |
+| `analytics_overview`         | Qual é o volume geral disponível para análise?                  |
+| `analytics_activity_daily`   | Como a participação agregada mudou ao longo do tempo?           |
+| `analytics_channel_activity` | Em quais canais houve atividade, sem comparar pessoas?          |
+| `analytics_audio_activity`   | Quantos eventos e movimentos de voz foram registrados?          |
+| `analytics_retention_cohort` | Grupos de entrada voltaram a participar nos períodos seguintes? |
+| `analytics_data_quality`     | Qual período cada fonte cobre e quais limitações ela possui?    |
+
+Antes de conectar o Metabase, as saídas precisam ser revisadas como se fossem um dataset público interno: se uma coluna permitir identificar uma pessoa, ela não entra na view.
+
+## 2. Criar uma conta de banco somente leitura
+
+O Metabase deve usar uma conta dedicada, como `analytics_reader`. Essa conta terá `SELECT` apenas nas views aprovadas. Ela não receberá acesso às tabelas de origem nem permissões de `INSERT`, `UPDATE`, `DELETE`, `CREATE`, `ALTER` ou `DROP`.
+
+A implantação deve provar essa fronteira com duas verificações:
+
+1. uma consulta agregada retorna dados;
+2. uma tentativa de escrita é negada pelo MariaDB.
+
+As permissões do Metabase ajudam a organizar quem pode editar ou visualizar dashboards, mas não substituem a proteção no banco. Mesmo uma conta administradora do Metabase deve continuar limitada pelas permissões de `analytics_reader` ao consultar os dados do Checkin Bot.
+
+## 3. Separar o banco da aplicação Metabase
+
+O Metabase precisa guardar sua própria configuração: contas, grupos, perguntas, filtros e dashboards. Esse banco é diferente do banco analisado.
+
+Para produção, a recomendação é usar PostgreSQL como banco da aplicação Metabase. MariaDB também é compatível e pode servir ao piloto, desde que use um database e uma conta exclusivos. Em qualquer opção:
+
+- não usar o banco H2 embutido;
+- manter backup periódico;
+- não reutilizar a conta `analytics_reader`;
+- não guardar senha no repositório;
+- testar restauração antes de considerar o serviço contínuo.
+
+Perder esse banco não apaga os dados coletados pelo bot, mas apaga o trabalho feito dentro do Metabase, como dashboards e configurações de acesso.
+
+## 4. Isolar a infraestrutura de analytics
+
+A implantação será descrita em um Compose próprio, planejado como `compose.analytics.prod.yml`. Ele poderá compartilhar uma rede privada com o MariaDB ou acessar um endereço privado do banco, mas não fará parte obrigatória da inicialização do worker.
+
+O novo Compose deve incluir:
+
+- imagem do Metabase com versão fixada;
+- conexão com o banco próprio da aplicação;
+- healthcheck em `/api/health`;
+- limites de memória e política de reinício adequados ao servidor;
+- variáveis obrigatórias sem senhas padrão;
+- rede privada para acessar a fonte analítica;
+- porta interna acessível somente pelo proxy HTTPS.
+
+O serviço `analytics-init` da PoC não será reutilizado em produção porque ele cria o dataset simulado. A criação das views e dos usuários reais deve ser uma operação explícita, revisada e executada antes da conexão do Metabase.
+
+## 5. Publicar com HTTPS e acesso privado
+
+O Metabase não deve responder diretamente pela porta `3001` na internet. Um proxy reverso, escolhido de acordo com o ambiente do servidor, recebe as conexões HTTPS e encaminha apenas o tráfego autorizado ao container.
+
+O desenho esperado é:
+
+```text
+Pessoa autorizada
+    ↓ https://subdomínio-a-definir
+Proxy reverso com TLS
+    ↓ rede privada
+Metabase:3000
+```
+
+O subdomínio ainda precisa ser decidido. Homologação e produção devem usar endereços diferentes para evitar que uma validação seja confundida com o serviço oficial.
+
+Não haverá compartilhamento público de perguntas ou dashboards. Cada pessoa receberá uma conta própria e o acesso será removido quando deixar de ser necessário.
+
+## 6. Fazer um deploy independente do bot
+
+O workflow atual `.github/workflows/deploy-prod.yml` acompanha a imagem do worker e executa o profile `prod`. Ele não sobe o profile `analytics`, e essa separação é saudável.
+
+A proposta é criar um workflow próprio para analytics, inicialmente manual com `workflow_dispatch`. Ele deverá:
+
+1. confirmar que as validações da branch foram aprovadas;
+2. conectar ao servidor autorizado;
+3. atualizar somente os arquivos da stack analítica;
+4. baixar a imagem fixada do Metabase;
+5. subir `compose.analytics.prod.yml`;
+6. aguardar o healthcheck;
+7. executar um smoke test sem dados pessoais;
+8. encerrar com falha se a saúde ou as permissões estiverem incorretas.
+
+Depois que homologação estiver estável, o grupo poderá decidir se produção continuará manual ou terá uma automação própria. Uma publicação do bot não deve reiniciar o Metabase sem necessidade, e uma manutenção do Metabase não deve interromper a coleta do Discord.
+
+## 7. Configurar o painel sem credenciais de demonstração
+
+O script `analytics/metabase/bootstrap.mjs` comprovou que a fonte, as coleções e o dashboard podem ser criados de forma repetível. Para um ambiente compartilhado, ele precisa deixar de depender das contas locais `@checkin.local` e das senhas de demonstração.
+
+A implantação pode manter a automação dos objetos de conteúdo, mas deve tratar pessoas e senhas separadamente:
+
+- administração cria ou convida contas reais por um canal seguro;
+- os segredos ficam somente no ambiente do servidor ou no cofre adotado pelo projeto;
+- o bootstrap não imprime senhas nos logs;
+- uma reexecução não amplia permissões por acidente;
+- contas de leitura não recebem permissão de curadoria.
+
+Os três perfis continuam úteis:
+
+| Perfil           | Pode fazer                                                  |
+| ---------------- | ----------------------------------------------------------- |
+| Administração    | Configurar a instância e administrar acessos                |
+| Edição/curadoria | Criar e organizar perguntas e painéis na coleção autorizada |
+| Somente leitura  | Abrir dashboards e usar os filtros disponíveis              |
+
+## 8. Validar homologação antes de produção
+
+Homologação não termina quando a página abre. A validação precisa percorrer o caminho completo:
+
+```text
+browser → HTTPS → Metabase → analytics_reader → views → MariaDB
+```
+
+### 🧪 Validações obrigatórias
+
+- `/api/health` responde com o serviço saudável;
+- a URL pública usa HTTPS e a porta interna não fica exposta;
+- cada perfil acessa apenas o que foi previsto;
+- uma pessoa leitora não consegue editar a coleção;
+- `analytics_reader` consulta as views e não consegue escrever;
+- nenhuma pergunta, download ou metadado expõe nome, e-mail ou ID pessoal;
+- filtros de período e canal funcionam com dados reais autorizados;
+- cobertura e limitações aparecem junto das métricas;
+- o uso de CPU e memória não prejudica o worker nem o MariaDB;
+- backup e restauração do banco da aplicação Metabase são exercitados;
+- a sessão coletiva de leitura e autonomia prevista no Spike é realizada.
+
+Dados reais só devem entrar nessa homologação depois da revisão das views e da autorização organizacional de acesso. A implantação técnica não substitui decisões sobre base legal, retenção, descarte ou atendimento a titulares.
+
+## 9. Publicar produção de forma gradual
+
+Depois da homologação, a primeira abertura de produção deve ser pequena:
+
+1. criar a instância e restaurar somente configurações aprovadas;
+2. conectar a conta somente leitura às views revisadas;
+3. convidar um grupo inicial de pessoas autorizadas;
+4. acompanhar erros, consultas lentas e consumo de recursos;
+5. ampliar o acesso apenas depois de confirmar que o painel apoia a conversa coletiva sem estimular leitura individualizante.
+
+Se as consultas começarem a disputar recursos com a coleta, o próximo passo não é aumentar o acesso ao banco operacional. A evolução recomendada é criar uma réplica somente leitura ou materializar agregados em um banco analítico atualizado periodicamente.
+
+## Plano de retorno
+
+Como o Metabase usa uma conta somente leitura, interromper analytics não precisa interromper o Checkin Bot.
+
+Em caso de problema:
+
+1. retirar a rota pública no proxy ou restringir o acesso;
+2. parar somente a stack `compose.analytics.prod.yml`;
+3. preservar logs e o banco da aplicação para diagnóstico;
+4. restaurar o último backup se a configuração do Metabase tiver sido corrompida;
+5. manter o worker e o banco operacional funcionando;
+6. reabrir o acesso somente após repetir as validações de homologação.
+
+## Entregas necessárias para implementar este plano
+
+| Entrega                                           | Estado atual |
+| ------------------------------------------------- | ------------ |
+| Views agregadas sobre o schema real               | Planejada    |
+| Usuário de produção somente leitura               | Planejado    |
+| `compose.analytics.prod.yml`                      | Planejado    |
+| Banco persistente da aplicação Metabase           | Planejado    |
+| Proxy HTTPS e subdomínios de homologação/produção | Planejado    |
+| Workflow independente de deploy                   | Planejado    |
+| Bootstrap sem credenciais locais                  | Planejado    |
+| Backup, restauração e observabilidade             | Planejado    |
+| Validação coletiva e decisão final do ADR         | Pendente     |
+
+## Critérios para considerar a implantação concluída
+
+A implantação estará pronta quando houver evidência de que:
+
+- homologação e produção são ambientes identificáveis e separados;
+- o painel usa apenas views agregadas e uma conta sem escrita;
+- o acesso é privado, autenticado e protegido por HTTPS;
+- credenciais não aparecem em código, documentação, commits ou logs;
+- o banco da aplicação possui backup e restauração testados;
+- o Metabase pode ser parado sem interromper o Checkin Bot;
+- o consumo de recursos foi aceito para a infraestrutura escolhida;
+- as limitações de cobertura aparecem junto dos números;
+- a validação coletiva aprovou o uso da ferramenta;
+- o ADR deixou de ser apenas proposto e registrou a decisão do grupo.
+
+## Próximos passos
+
+1. revisar este plano com desenvolvimento, dados e pessoas responsáveis pelo servidor;
+2. realizar a sessão coletiva ainda pendente na PoC;
+3. escolher subdomínios e responsáveis pelos acessos;
+4. implementar primeiro as views reais e provar a conta somente leitura;
+5. preparar o Compose e o workflow de homologação;
+6. validar o fluxo completo antes de decidir pela produção.
+
+## 📚 Documentos relacionados
+
+- [Spike 0001 — Ferramenta de análise de dados](./spike/0001-ferramenta-analise-dados.md)
+- [ADR 0001 — Metabase para análise dos dados](./adr/0001-metabase-para-analise-de-dados.md)
+- [Sincronização Histórica](./8%20-%20Sincronização%20Histórica.md)
+- [Documentação de Produto](./0%20-%20Documentação%20de%20Produto.md)
+- [Documentação técnica](./1%20-%20Documentação%20técnica.md)
+
+## Referências oficiais
+
+- [Executar o Metabase com Docker](https://www.metabase.com/docs/latest/installation-and-operation/running-metabase-on-docker)
+- [Configurar o banco da aplicação Metabase](https://www.metabase.com/docs/latest/installation-and-operation/configuring-application-database)
+- [Usuários, papéis e privilégios no banco analisado](https://www.metabase.com/docs/latest/databases/users-roles-privileges)
+- [Configurações gerais, URL do site e HTTPS](https://www.metabase.com/docs/latest/configuring-metabase/settings)

--- a/docs/adr/0001-metabase-para-analise-de-dados.md
+++ b/docs/adr/0001-metabase-para-analise-de-dados.md
@@ -24,4 +24,4 @@ Os cenários técnicos de reprodutibilidade, conexão, filtros, somente leitura 
 - Permissões de coleção serão usadas para testar administração, curadoria e visualização; permissões granulares de dados e da aplicação, disponíveis nos planos pagos, não serão tratadas como capacidades da PoC.
 - Se qualquer um dos três cenários de homologação falhar de forma relevante, o Metabase não será aceito e o Apache Superset será a alternativa seguinte.
 
-As evidências, a matriz comparativa, o dicionário de métricas e o protocolo de validação estão no [relatório do Spike](../spike/0001-ferramenta-analise-dados.md).
+As evidências, a matriz comparativa, o dicionário de métricas e o protocolo de validação estão no [relatório do Spike](../spike/0001-ferramenta-analise-dados.md). As entregas ainda necessárias para homologação e produção estão descritas no [Plano de implantação do Metabase](../9%20-%20Plano%20de%20implantação%20do%20Metabase.md).

--- a/docs/adr/0001-metabase-para-analise-de-dados.md
+++ b/docs/adr/0001-metabase-para-analise-de-dados.md
@@ -1,0 +1,27 @@
+---
+status: proposed
+date: 2026-08-26
+---
+
+# Metabase Open Source para análise dos dados do Check-In
+
+Propomos o Metabase Open Source como primeira ferramenta de análise e visualização do Check-In porque ele oferece o melhor equilíbrio inicial entre self-hosting, conexão com MariaDB/MySQL e acessibilidade para pessoas não especialistas. A decisão permanecerá proposta até a PoC comprovar ambiente reproduzível, painel conectado e autonomia de uso em uma validação coletiva.
+
+Os cenários técnicos de reprodutibilidade, conexão, filtros, somente leitura e permissões de coleção foram aprovados em 26 de agosto de 2026. A decisão continua proposta porque a sessão de diálogo e autonomia com pessoas de diferentes perfis ainda precisa ser realizada, e o grupo deve avaliar se o consumo observado de aproximadamente 1,4 GiB é aceitável.
+
+## Opções consideradas
+
+- **Metabase Open Source:** favorito pela interface de BI voltada à exploração de dados relacionais e pela expectativa de menor curva de aprendizado.
+- **Apache Superset:** segunda opção por oferecer análise avançada e permissões mais granulares, com maior custo operacional e de aprendizado.
+- **Grafana Open Source:** adequado para observabilidade e séries temporais, mas menos alinhado à exploração comunitária de dados relacionais.
+
+## Consequências
+
+- A PoC usará apenas dados simulados e agregados.
+- O Metabase se conectará por um usuário MariaDB somente leitura a views analíticas que excluem nomes, e-mails, IDs pessoais e conteúdo de mensagens.
+- O painel inicial será “Saúde da Comunidade”, com filtros de período e canal e sem rankings individuais.
+- A validação considerará apenas recursos disponíveis na edição open source.
+- Permissões de coleção serão usadas para testar administração, curadoria e visualização; permissões granulares de dados e da aplicação, disponíveis nos planos pagos, não serão tratadas como capacidades da PoC.
+- Se qualquer um dos três cenários de homologação falhar de forma relevante, o Metabase não será aceito e o Apache Superset será a alternativa seguinte.
+
+As evidências, a matriz comparativa, o dicionário de métricas e o protocolo de validação estão no [relatório do Spike](../spike/0001-ferramenta-analise-dados.md).

--- a/docs/spike/0001-ferramenta-analise-dados.md
+++ b/docs/spike/0001-ferramenta-analise-dados.md
@@ -1,0 +1,363 @@
+# Spike 0001 — Ferramenta open source de análise de dados
+
+**Data da pesquisa:** 26 de agosto de 2026
+**Status:** comparação e PoC concluídas; validação coletiva pendente
+**Ferramenta favorita para a PoC:** Metabase Open Source
+
+## Descrição
+
+### O que é esta atividade?
+
+Este Spike analisa e compara ferramentas open source de análise e visualização de dados para integrar o ecossistema do Check-In. A pesquisa considera Metabase, Apache Superset e Grafana e propõe uma prova de conceito com a alternativa que melhor atende às necessidades atuais do projeto.
+
+### Por que ela é necessária?
+
+O Check-In já transforma sinais mínimos de participação no Discord em dados relacionais, mas ainda não oferece uma camada de leitura acessível. A ferramenta escolhida precisa equilibrar eficiência técnica, custo de infraestrutura, segurança e, sobretudo, simplicidade para que pessoas contribuidoras com diferentes níveis de conhecimento consigam interpretar e discutir a saúde da comunidade.
+
+O painel não será um instrumento de vigilância individual. Ele deve usar dados agregados, não expor conteúdo de conversas e não mostrar nomes, e-mails, identificadores ou rankings de pessoas.
+
+## Estado dos critérios de aceite
+
+- [x] **Mapeamento de ferramentas:** Metabase, Apache Superset e Grafana foram avaliados quanto a licença, arquitetura e self-hosting.
+- [x] **Matriz comparativa:** requisitos técnicos, conectores, acessibilidade e controle de acesso foram comparados abaixo.
+- [x] **Prova de Conceito:** ambiente reproduzível, dataset simulado, views somente leitura e painel com 11 cartões foram implementados e medidos.
+- [ ] **Recomendação final:** o [ADR](../adr/0001-metabase-para-analise-de-dados.md) está proposto e só poderá ser aceito após a PoC e a validação coletiva.
+
+## Critérios da comparação
+
+| Critério               | Pergunta simples                                                                                    |
+| ---------------------- | --------------------------------------------------------------------------------------------------- |
+| Licença                | Podemos usar, estudar e hospedar a ferramenta como software livre?                                  |
+| Arquitetura e operação | Quantos componentes precisam ser mantidos e quão difícil é subir o ambiente?                        |
+| Conectores             | A ferramenta consulta MariaDB/MySQL sem uma integração feita pelo projeto?                          |
+| Recursos               | Qual é a expectativa inicial de consumo e o que precisa ser medido na PoC?                          |
+| Acessibilidade         | Uma pessoa não especialista consegue entender um painel e aplicar filtros?                          |
+| Segurança e RBAC       | É possível separar quem administra, edita e apenas consulta? Quais limites existem na edição livre? |
+
+As avaliações de consumo e facilidade de uso são hipóteses comparativas. Elas não substituem as medições e o teste com pessoas previstos para a PoC.
+
+## Mapeamento das ferramentas
+
+### Metabase Open Source
+
+O Metabase é uma ferramenta de BI voltada à exploração de bancos relacionais por interface gráfica, com suporte a perguntas, filtros, coleções e dashboards. A edição comunitária é distribuída sob AGPL e possui imagem Docker oficial. O projeto pode conectar o Metabase ao MariaDB/MySQL sem desenvolver um conector próprio.
+
+Para este projeto, sua principal vantagem é a menor barreira de entrada esperada para quem não trabalha diariamente com SQL. A principal limitação está nas permissões: a edição open source permite organizar conteúdo em coleções com acesso de curadoria, visualização ou nenhum acesso, mas permissões granulares sobre dados, linhas, colunas e partes administrativas ficam nos planos Pro e Enterprise. Portanto, a proteção principal da PoC deve existir no próprio MariaDB, por meio de um usuário somente leitura e views que já excluam dados pessoais.
+
+Arquitetura inicial para self-hosting:
+
+```text
+Metabase (aplicação JVM)
+    ├── banco da aplicação, para usuários, perguntas e dashboards
+    └── conexão somente leitura com as views analíticas do Check-In
+```
+
+Leitura inicial:
+
+- **Self-hosting:** simples para uma PoC, com imagem Docker oficial e um serviço principal.
+- **Conector:** oficial para MySQL/MariaDB.
+- **Recursos:** expectativa de consumo intermediário por executar na JVM; os números reais ainda serão medidos.
+- **Aprendizado:** menor curva esperada entre as três opções para perguntas e filtros básicos.
+- **RBAC OSS:** adequado para separar curadoria e visualização de coleções, mas insuficiente para isolamento granular de dados dentro do próprio Metabase.
+
+### Apache Superset
+
+O Apache Superset é uma plataforma de exploração e visualização de dados mais orientada a pessoas analistas e a cenários com consultas e dashboards avançados. Usa licença Apache-2.0 e possui um modelo de segurança granular baseado no Flask AppBuilder, com papéis como Admin, Alpha e Gamma e permissões por fonte de dados.
+
+Essa flexibilidade cobra um custo operacional maior. A configuração Docker Compose oficial envolve mais peças e a própria documentação alerta que o ambiente fornecido não está pronto para produção sem trabalho adicional. O uso de MySQL/MariaDB também requer configurar o driver correspondente.
+
+Arquitetura inicial para self-hosting:
+
+```text
+Superset web
+    ├── banco de metadados
+    ├── cache e workers quando usados recursos assíncronos
+    └── conexão com o banco analítico do Check-In
+```
+
+Leitura inicial:
+
+- **Self-hosting:** reproduzível por Docker, mas com mais componentes e configuração.
+- **Conector:** compatível com MySQL/MariaDB mediante driver.
+- **Recursos:** expectativa de maior consumo e manutenção entre as três opções.
+- **Aprendizado:** mais poderoso, porém menos direto para pessoas iniciantes.
+- **RBAC OSS:** é o modelo mais granular das alternativas avaliadas.
+
+### Grafana Open Source
+
+O Grafana é muito maduro para observabilidade, monitoramento e séries temporais. A edição open source usa AGPL e pode ser executada por imagem Docker. Seu datasource MySQL é integrado e também suporta MariaDB; a documentação recomenda um usuário dedicado com permissão apenas de leitura.
+
+Ele oferece papéis de organização como administrador, editor e visualizador, além de permissões de dashboards e pastas. Entretanto, sua experiência principal é mais adequada a painéis operacionais e séries temporais do que à exploração livre de um modelo relacional por pessoas não especialistas.
+
+Arquitetura inicial para self-hosting:
+
+```text
+Grafana
+    ├── armazenamento da configuração e dos dashboards
+    └── datasource MySQL/MariaDB somente leitura
+```
+
+Leitura inicial:
+
+- **Self-hosting:** simples, com imagem Docker oficial e um serviço principal.
+- **Conector:** datasource MySQL integrado e compatível com MariaDB.
+- **Recursos:** expectativa de consumo baixo a intermediário; precisa ser medido em cenário equivalente para uma conclusão numérica.
+- **Aprendizado:** simples para consumir dashboards, mas menos amigável para exploração relacional sem SQL.
+- **RBAC OSS:** papéis claros de administrador, editor e visualizador; controles mais avançados variam conforme a edição.
+
+## Matriz comparativa
+
+| Dimensão                          | Metabase Open Source                                    | Apache Superset                                                | Grafana Open Source                                               |
+| --------------------------------- | ------------------------------------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Licença                           | AGPL para a edição comunitária                          | Apache-2.0                                                     | AGPLv3                                                            |
+| Foco principal                    | BI e exploração de dados relacionais                    | BI avançado e exploração analítica                             | Observabilidade e séries temporais                                |
+| Arquitetura da PoC                | Aplicação JVM + banco de metadados                      | Aplicação web + metadados; cache/workers conforme configuração | Servidor Grafana + armazenamento de configuração                  |
+| Facilidade de self-hosting        | **Alta** para ambiente local                            | **Média**; mais peças e configuração                           | **Alta** para ambiente local                                      |
+| MariaDB/MySQL                     | Conector oficial                                        | Compatível mediante driver                                     | Datasource integrado                                              |
+| Consumo esperado                  | Médio; medir na PoC                                     | Médio/alto; arquitetura mais ampla                             | Baixo/médio; depende das consultas                                |
+| Criação sem SQL                   | **Muito favorável** para perguntas comuns               | Favorável, com mais conceitos analíticos                       | Possível, mas o datasource relacional frequentemente exige SQL    |
+| Leitura por não especialistas     | **Hipótese mais forte**                                 | Boa depois de treinamento                                      | Boa em painéis prontos, menos autônoma na exploração              |
+| Controle de conteúdo              | Coleções com Curate, View e No access                   | Papéis e permissões granulares                                 | Papéis e permissões de dashboards/pastas                          |
+| Limite relevante da edição OSS    | Permissões granulares de dados e da aplicação são pagas | Maior complexidade de configuração e manutenção                | Viewer ainda consulta datasources; RBAC avançado varia por edição |
+| Adequação ao objetivo comunitário | **Alta**                                                | Média/alta                                                     | Média                                                             |
+
+## Recomendação inicial
+
+O **Metabase Open Source** é a ferramenta escolhida para a PoC. Ele apresenta o melhor equilíbrio inicial entre conexão com MariaDB/MySQL, facilidade de self-hosting e autonomia esperada para pessoas não especialistas.
+
+Esta recomendação é **proposta**, não definitiva. O Metabase só será aceito se passar pelos três cenários de homologação. Se falhar, a segunda opção será o Apache Superset, que oferece controle de acesso mais granular, mas exige maior esforço operacional e de aprendizado.
+
+## Arquitetura proposta para a PoC
+
+```text
+Dataset simulado e fiel ao schema do Check-In
+    ↓
+MariaDB/MySQL
+    ↓
+Views SQL agregadas
+    ↓
+Usuário com permissão somente SELECT
+    ↓
+Metabase Open Source
+    ↓
+Painel “Saúde da Comunidade”
+```
+
+Decisões já aceitas:
+
+- executar o Metabase apenas no profile Docker Compose `analytics`;
+- disponibilizar a interface localmente na porta `3001`;
+- usar dados simulados, determinísticos e sem relação com pessoas reais;
+- manter os dados operacionais como fonte de verdade;
+- expor ao BI somente views agregadas e um usuário sem escrita;
+- atualizar os dados sob demanda ou periodicamente, sem exigir tempo real;
+- medir recursos antes de definir um limite rígido;
+- testar apenas recursos existentes na edição open source.
+
+O comando de uso é:
+
+```bash
+docker compose --profile analytics up -d
+```
+
+Esse comando sobe o profile completo para que preparação do banco, Metabase e configuração inicial não sejam esquecidas.
+
+## Como executar a PoC
+
+Pré-requisito: Docker com o plugin Docker Compose.
+
+1. Copie `.env.example` para `.env` caso o ambiente ainda não esteja configurado.
+2. Suba o profile analítico:
+
+   ```bash
+   docker compose --profile analytics up -d
+   ```
+
+3. Acompanhe o provisionamento automático:
+
+   ```bash
+   docker compose --profile analytics logs -f metabase-bootstrap
+   ```
+
+4. Quando o bootstrap mostrar `"status": "ok"`, acesse [http://localhost:3001](http://localhost:3001).
+
+Credenciais padrão exclusivamente locais:
+
+| Perfil           | E-mail                  | Senha local        |
+| ---------------- | ----------------------- | ------------------ |
+| Administração    | `admin@checkin.local`   | `CheckinLocal123!` |
+| Edição/curadoria | `editora@checkin.local` | `CheckinLocal123!` |
+| Somente leitura  | `leitora@checkin.local` | `CheckinLocal123!` |
+
+Essas credenciais existem apenas para a PoC. Devem ser substituídas pelas variáveis documentadas em `.env.example` antes de qualquer ambiente compartilhado. O serviço fica vinculado a `127.0.0.1`, sem exposição direta à rede.
+
+Para interromper apenas a interface analítica:
+
+```bash
+docker compose stop metabase
+```
+
+O bootstrap é idempotente: executar novamente o comando de subida atualiza o dataset simulado e preserva uma única fonte, coleção e dashboard.
+
+Arquivos principais da PoC:
+
+- `compose.yml`: profile `analytics` e serviços de inicialização;
+- `analytics/database/bootstrap.sh`: bancos, usuários e prova de bloqueio de escrita;
+- `analytics/database/schema-and-seed.sql`: schema compatível, dados simulados e views;
+- `analytics/metabase/bootstrap.mjs`: configuração idempotente da fonte, usuários, permissões, perguntas, filtros e dashboard.
+
+## Painel “Saúde da Comunidade”
+
+O primeiro painel deve responder perguntas coletivas, não avaliar indivíduos:
+
+- quantas pessoas participaram no período;
+- como mensagens, reações e participação em voz evoluíram no tempo;
+- quais canais mobilizaram mais participação agregada;
+- quantos eventos de voz ocorreram e quantas presenças tiveram;
+- como grupos de entrada permanecem ativos ao longo do tempo;
+- qual período e quais fontes possuem dados suficientes para análise.
+
+Filtros mínimos:
+
+- período;
+- canal.
+
+Elementos mínimos:
+
+- cartões com usuários, canais, mensagens, reações e eventos;
+- série temporal de mensagens e participantes ativos;
+- participação agregada por canal;
+- eventos e presenças em voz;
+- retenção por coorte;
+- quadro de cobertura e qualidade dos dados.
+
+## Dicionário inicial de métricas
+
+| Métrica      | Definição inicial                                                                     | Explicação simples                                                      |
+| ------------ | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Membro ativo | Pessoa não-bot com ao menos uma mensagem, reação ou participação em voz no período    | Participou de alguma forma observável, sem analisar o conteúdo.         |
+| Participação | Ocorrência agregada de mensagem, reação ou presença em voz                            | Mede sinais de presença, não qualidade ou opinião.                      |
+| Retenção     | Parcela de uma coorte de entrada que volta a ter participação em um período posterior | Mostra se grupos novos continuam presentes com o passar do tempo.       |
+| Reativação   | Pessoa sem participação em uma janela anterior que volta a participar                 | Indica retorno, sem atribuir causa ao comportamento.                    |
+| Canal ativo  | Canal com ao menos uma participação registrada no período                             | Mostra onde houve atividade, não se a conversa foi boa ou ruim.         |
+| Cobertura    | Intervalo e fontes para os quais a coleta é considerada utilizável                    | Ajuda a não interpretar falta de dados como queda real de participação. |
+
+Para eventos do Discord, a análise deve preferir a data original da plataforma, como `platform_created_at`, e não a data de importação do registro. As regras acima ainda serão materializadas e testadas nas views SQL.
+
+## Privacidade e segurança
+
+A PoC deve aplicar proteção em duas camadas:
+
+1. **No banco:** usuário somente leitura e views que não exponham nome, e-mail, identificador de usuário nem conteúdo de mensagem.
+2. **No Metabase:** coleções separadas para administração, curadoria e visualização, dentro do que a edição comunitária realmente oferece.
+
+Não serão permitidos:
+
+- rankings de pessoas;
+- tabelas com atividade individual;
+- e-mails, nomes ou IDs pessoais;
+- conteúdo de mensagens, mídias ou gravações;
+- publicação anônima do painel;
+- conexão do BI com credenciais capazes de alterar o banco.
+
+O teste de RBAC verificará três experiências: administração, edição/curadoria e somente leitura. Como o Metabase OSS não oferece isolamento granular de dados por grupo, as views e as permissões do MariaDB são uma condição arquitetural, e não apenas uma conveniência.
+
+## Medições da PoC
+
+Medições locais em WSL2, Docker e Metabase `v0.63.14`, em 26 de agosto de 2026:
+
+| Medição                                     |                Resultado observado |
+| ------------------------------------------- | ---------------------------------: |
+| Reinicialização com banco já preparado      | 16,5 s até `/api/health` responder |
+| Memória apó a carga do painel               |           aproximadamente 1,39 GiB |
+| Onze consultas sem cache, em sequência      |                    862 ms no total |
+| Consulta individual mais lenta              |                             236 ms |
+| Renderização e filtro de canal no navegador |      concluídos sem erro funcional |
+
+O consumo de memória é relevante para um projeto pequeno e deve entrar na decisão coletiva. Não houve falta de memória, travamento ou consulta lenta no dataset da PoC, mas um ambiente de homologação deve confirmar se aproximadamente 1,4 GiB é um custo aceitável.
+
+## Como validar em homologação
+
+### Cenário 1: execução e reprodutibilidade
+
+1. Baixar a branch do Spike.
+2. Executar o comando documentado de subida do profile `analytics`.
+3. Confirmar que o serviço fica saudável e acessível em `http://localhost:3001`.
+
+**Resultado esperado:** o ambiente sobe sem configuração manual não documentada e sem interferir no funcionamento normal do bot.
+
+### Cenário 2: conexão e painel
+
+1. Acessar o Metabase.
+2. Confirmar a conexão somente leitura com a fonte simulada.
+3. Abrir o painel “Saúde da Comunidade”.
+4. Alterar período e canal.
+
+**Resultado esperado:** os gráficos mostram dados legíveis, os filtros funcionam, nenhuma informação individual aparece e a ferramenta não consegue escrever no banco.
+
+### Cenário 3: diálogo e autonomia
+
+1. Convidar pessoas com diferentes níveis de conhecimento técnico.
+2. Pedir que interpretem um gráfico, mudem o período e apliquem um filtro básico sem demonstração prévia.
+3. Registrar tempo aproximado, dúvidas e dificuldades sem identificar publicamente as pessoas.
+
+**Resultado esperado:** uma pessoa não especialista consegue explicar o gráfico e usar os filtros básicos. Dificuldades relevantes devem virar ajustes ou impedir a aceitação definitiva da ferramenta.
+
+## Evidências
+
+| Evidência                     | Estado                                                                                                                        |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Ambiente reproduzível         | Aprovado em projeto Docker isolado e volume novo                                                                              |
+| Dataset simulado              | Aprovado: 30 usuários, sendo 29 membros não-bot, 4 canais, 180 mensagens, 90 reações, 6 eventos de voz e 60 movimentos em voz |
+| Views somente leitura         | Aprovado: seis views visíveis; tentativa de `UPDATE` negada                                                                   |
+| Painel com filtros            | Aprovado: 11 cartões, filtro de período e filtro de canal provisionados                                                       |
+| Medições de recursos          | Concluído no ambiente local; valores registrados acima                                                                        |
+| Teste prático de RBAC OSS     | Aprovado nos limites da edição: editora altera a coleção; leitora consulta e recebe `403` ao editar                           |
+| Sessão de diálogo e autonomia | Pendente de realização pelo grupo                                                                                             |
+
+## Riscos e próximos passos
+
+- O RBAC de dados da edição open source do Metabase é menos granular que o do Superset. A PoC comprovou a fronteira de banco e views somente leitura, mas o grupo ainda precisa decidir se ela é suficiente para o uso pretendido.
+- A documentação arquitetural existente possui trechos divergentes da estrutura atual do código. A correção completa ficará em uma tarefa separada para não ampliar este Spike.
+- Dados históricos podem ter cobertura desigual. O painel precisa mostrar essa limitação junto das métricas.
+- A aplicação foi normalizada na porta `3000` do `.env.example` e a porta `3001` foi reservada para o Metabase. Arquivos `.env` locais antigos podem precisar do mesmo ajuste caso os profiles `dev` e `analytics` sejam executados juntos.
+
+Próxima sequência:
+
+1. realizar a sessão coletiva de diálogo e autonomia;
+2. registrar tempos, dúvidas e dificuldades sem identificar as pessoas;
+3. decidir coletivamente se o consumo aproximado de 1,4 GiB é aceitável;
+4. aceitar o ADR somente se os três cenários forem aprovados.
+
+## Fontes oficiais
+
+### Metabase
+
+- [Licença do Metabase](https://github.com/metabase/metabase/blob/master/LICENSE.txt)
+- [Execução do Metabase Open Source com Docker](https://www.metabase.com/docs/latest/installation-and-operation/running-metabase-on-docker)
+- [Conexão com MySQL/MariaDB](https://www.metabase.com/docs/latest/databases/connections/mysql)
+- [Permissões de coleções](https://www.metabase.com/docs/latest/permissions/collections)
+- [Permissões de dados e limites da edição OSS](https://www.metabase.com/docs/latest/permissions/data)
+- [Permissões de aplicação](https://www.metabase.com/docs/latest/permissions/application)
+
+### Apache Superset
+
+- [Licença Apache-2.0](https://github.com/apache/superset/blob/master/LICENSE.txt)
+- [Instalação com Docker Compose](https://superset.apache.org/admin-docs/installation/docker-compose/)
+- [Segurança, papéis e permissões](https://superset.apache.org/admin-docs/security/)
+- [Conexão com MySQL](https://superset.apache.org/docs/databases/supported/mysql/)
+
+### Grafana
+
+- [Licença AGPLv3](https://github.com/grafana/grafana/blob/main/LICENSE)
+- [Instalação com Docker](https://grafana.com/docs/grafana/latest/setup-grafana/installation/docker/)
+- [Datasource MySQL/MariaDB](https://grafana.com/docs/grafana/latest/datasources/mysql/configure/)
+- [Papéis e permissões](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/)
+
+## Documentos relacionados
+
+- [Decisões aceitas durante o grilling](./grilling.md)
+- [ADR proposto: Metabase para análise dos dados](../adr/0001-metabase-para-analise-de-dados.md)
+- [Documentação de Produto](../0%20-%20Documentação%20de%20Produto.md)
+- [Entidades Principais](../6%20-%20Entidades%20Principais.md)
+- [Sincronização Histórica](../8%20-%20Sincronização%20Histórica.md)

--- a/docs/spike/0001-ferramenta-analise-dados.md
+++ b/docs/spike/0001-ferramenta-analise-dados.md
@@ -329,6 +329,8 @@ Próxima sequência:
 3. decidir coletivamente se o consumo aproximado de 1,4 GiB é aceitável;
 4. aceitar o ADR somente se os três cenários forem aprovados.
 
+O caminho proposto para levar a PoC a um ambiente compartilhado está registrado no [Plano de implantação do Metabase](../9%20-%20Plano%20de%20implantação%20do%20Metabase.md). O plano separa o que já foi comprovado localmente das entregas ainda necessárias para homologação e produção.
+
 ## Fontes oficiais
 
 ### Metabase
@@ -358,6 +360,7 @@ Próxima sequência:
 
 - [Decisões aceitas durante o grilling](./grilling.md)
 - [ADR proposto: Metabase para análise dos dados](../adr/0001-metabase-para-analise-de-dados.md)
+- [Plano de implantação do Metabase](../9%20-%20Plano%20de%20implantação%20do%20Metabase.md)
 - [Documentação de Produto](../0%20-%20Documentação%20de%20Produto.md)
 - [Entidades Principais](../6%20-%20Entidades%20Principais.md)
 - [Sincronização Histórica](../8%20-%20Sincronização%20Histórica.md)

--- a/docs/spike/grilling.md
+++ b/docs/spike/grilling.md
@@ -1,0 +1,245 @@
+Seguindo o `grill-with-docs`, consolidei todas as decisões de uma vez. Cada item traz alternativas, explicação simples e minha recomendação.
+
+## 1. Escopo desta entrega
+
+- **A — Comparativo + ADR + PoC mínima — Recomendada**
+  Atende os quatro critérios de aceite na mesma branch.
+- **B — Somente comparativo e ADR**
+  Registra a pesquisa, mas deixa a tarefa incompleta porque não há ambiente executável.
+- **C — Somente PoC**
+  Prova a ferramenta, mas não documenta por que ela foi escolhida.
+
+**Resposta recomendada: A.**
+
+## 2. Organização da documentação
+
+- **A — Separar Spike e ADR — Recomendada**
+  Criar um relatório detalhado em `docs/spikes/0001-ferramenta-analise-dados.md` e um ADR curto em `docs/adr/0001-ferramenta-analise-dados.md`.
+- **B — Colocar tudo no ADR**
+  É mais simples, mas transforma o ADR em um relatório extenso e difícil de consultar.
+- **C — Registrar apenas no README**
+  Facilita a descoberta, mas mistura documentação operacional com decisão arquitetural.
+
+**Resposta recomendada: A.** O Spike guarda evidências e a matriz; o ADR registra a decisão e seus motivos.
+
+## 3. Estado inicial da decisão
+
+- **A — Metabase como decisão proposta — Recomendada**
+  O documento indica o favorito, mas só muda para “aceito” depois da PoC e do teste com pessoas.
+- **B — Metabase já aceito**
+  Encerra a decisão antes de validar consumo, permissões e acessibilidade.
+- **C — Sem ferramenta favorita**
+  Mantém neutralidade, mas ignora que já existe uma hipótese tecnicamente fundamentada.
+
+**Resposta recomendada: A.**
+
+## 4. Ferramentas comparadas
+
+- **A — Metabase, Apache Superset e Grafana — Recomendada**
+  Cobre uma ferramenta de BI acessível, uma plataforma analítica avançada e uma solução orientada a observabilidade.
+- **B — Comparar cinco ou mais ferramentas**
+  Amplia a pesquisa, mas aumenta bastante o Spike sem garantir uma decisão melhor.
+- **C — Comparar apenas Metabase e Grafana**
+  Não atende ao mínimo de três ferramentas.
+
+**Resposta recomendada: A.**
+
+## 5. Ferramenta usada na PoC
+
+- **A — Metabase Open Source — Recomendada**
+  É a hipótese mais coerente para pessoas não especialistas explorarem um banco relacional.
+- **B — Apache Superset**
+  Oferece mais flexibilidade analítica, com operação e aprendizado mais exigentes.
+- **C — Grafana**
+  Funciona bem para séries temporais e monitoramento, mas não é a hipótese mais forte para exploração comunitária dos dados.
+
+**Resposta recomendada: A.**
+
+## 6. Fonte de dados da PoC
+
+- **A — Dataset simulado, determinístico e fiel ao schema — Recomendada**
+  Qualquer pessoa pode reproduzir o painel sem receber nomes, IDs ou dados reais da comunidade.
+- **B — Cópia local restaurada do banco real**
+  Permite números reais, mas cria riscos de privacidade e dificulta compartilhar a PoC.
+- **C — Banco vazio com consultas demonstrativas**
+  É seguro, porém não comprova a construção de gráficos úteis.
+
+**Resposta recomendada: A.** O dataset deve imitar usuários, mensagens, reações, canais e eventos sem representar pessoas reais.
+
+## 7. Forma de acesso ao banco
+
+- **A — Usuário somente leitura e views analíticas — Recomendada**
+  A ferramenta enxerga apenas dados preparados para análise e não consegue alterar o banco operacional.
+- **B — Usuário comum diretamente nas tabelas**
+  É mais rápido de configurar, mas expõe campos desnecessários e permite maior acoplamento.
+- **C — Criar uma API antes do BI**
+  Dá controle completo, porém expande demasiadamente o escopo do Spike.
+
+**Resposta recomendada: A.**
+
+## 8. Conteúdo do primeiro painel
+
+- **A — Painel “Saúde da Comunidade” — Recomendada**
+  Mostra membros ativos, mensagens, reações, canais, eventos e evolução temporal.
+- **B — Painel de produtividade individual**
+  Facilita rankings, mas contraria a intenção comunitária e aumenta o risco de vigilância.
+- **C — Painel somente técnico**
+  Mostra banco, memória e disponibilidade, mas não responde às perguntas do produto.
+
+**Resposta recomendada: A.**
+
+O painel inicial deve conter:
+
+- membros ativos no período;
+- mensagens e participantes por dia;
+- reações por mensagem;
+- canais com maior participação;
+- eventos de voz e participantes;
+- filtros de período e canal;
+- indicador de cobertura dos dados.
+
+## 9. Identificação individual
+
+- **A — Apenas métricas agregadas — Recomendada**
+  Nomes, IDs, e-mails e rankings pessoais não aparecem no dataset do BI.
+- **B — Identificadores pseudonimizados**
+  Permite acompanhar indivíduos sem nomes, mas ainda possibilita reconstruir padrões pessoais.
+- **C — Nomes reais com acesso restrito**
+  Facilita análises individuais, mas entra em conflito com a finalidade declarada do projeto.
+
+**Resposta recomendada: A.**
+
+## 10. Métricas e definições
+
+- **A — Criar um pequeno dicionário de métricas — Recomendada**
+  Define exatamente o significado de “ativo”, “retenção”, “participação” e “reativação”.
+- **B — Deixar cada gráfico definir sua regra**
+  É rápido, mas diferentes painéis podem apresentar números contraditórios.
+- **C — Adiar as definições para depois da PoC**
+  Permite experimentar, porém enfraquece a validação dos resultados.
+
+**Resposta recomendada: A.**
+
+Definição inicial sugerida: membro ativo é uma pessoa não-bot que realizou ao menos uma mensagem, reação ou participação em evento de voz no período selecionado.
+
+## 11. Integração com Docker Compose
+
+- **A — Profile separado `analytics` — Recomendada**
+  O Metabase só sobe quando solicitado e não aumenta o consumo normal do bot.
+- **B — Metabase sempre ativo no profile `dev`**
+  Facilita o uso diário, mas torna o ambiente básico mais pesado.
+- **C — Compose independente em outra pasta**
+  Isola completamente a PoC, porém duplica configurações de rede e banco.
+
+**Resposta recomendada: A.**
+
+Comando esperado:
+
+```bash
+docker compose --profile analytics up -d db metabase
+```
+
+## 12. Porta da ferramenta
+
+- **A — Porta `3001` — Recomendada**
+  Evita conflito com aplicações que normalmente usam `3000`.
+- **B — Porta `3000`**
+  É convencional para aplicações web, mas pode conflitar com outros serviços.
+- **C — Porta configurada aleatoriamente**
+  Reduz conflitos locais, porém prejudica a documentação e a reprodutibilidade.
+
+**Resposta recomendada: A.**
+
+## 13. Atualização dos dados
+
+- **A — Atualização sob demanda ou periódica — Recomendada**
+  É suficiente para leitura comunitária e reduz complexidade.
+- **B — Tempo real obrigatório**
+  Parece atraente, mas não é necessário para decisões sobre tendências e retenção.
+- **C — Snapshot estático**
+  É simples para demonstração, mas não prova a conexão operacional com o banco.
+
+**Resposta recomendada: A.**
+
+## 14. Avaliação de recursos
+
+- **A — Medir e registrar, sem fixar limite antes da PoC — Recomendada**
+  Registrar memória em repouso, memória durante consultas, tempo de inicialização e tempo de abertura do painel.
+- **B — Definir um limite rígido agora**
+  Dá um critério objetivo, mas seria um número arbitrário sem medição do ambiente.
+- **C — Não medir recursos**
+  Ignora um dos critérios centrais da tarefa.
+
+**Resposta recomendada: A.** A PoC falha se ocorrer falta de memória, travamento ou lentidão que impeça o uso; os números observados serão registrados no ADR.
+
+## 15. Validação de segurança e RBAC
+
+- **A — Testar apenas recursos disponíveis na edição OSS — Recomendada**
+  Evita recomendar funcionalidades que exigiriam pagamento posteriormente.
+- **B — Considerar recursos pagos na avaliação**
+  Mostra possibilidades futuras, mas pode distorcer a decisão open source.
+- **C — Avaliar segurança apenas pela documentação**
+  É mais rápido, porém não comprova o comportamento real.
+
+**Resposta recomendada: A.** Devem ser testados administrador, pessoa editora e pessoa somente leitora, dentro dos limites reais da edição comunitária.
+
+## 16. Teste de diálogo e autonomia
+
+- **A — Tarefas curtas com pessoas de perfis diferentes — Recomendada**
+  Pedir para interpretar um gráfico, alterar um período e aplicar um filtro.
+- **B — Demonstração conduzida pela pessoa desenvolvedora**
+  Mostra o painel, mas não comprova autonomia.
+- **C — Formulário sem interação prática**
+  Coleta opiniões gerais, sem verificar se a interface é realmente utilizável.
+
+**Resposta recomendada: A.**
+
+O registro deve guardar dificuldades e tempo aproximado, sem identificar publicamente as pessoas participantes.
+
+## 17. Critério para aceitar definitivamente o Metabase
+
+- **A — Aceitar somente após cumprir os três cenários — Recomendada**
+  Exige ambiente reproduzível, painel conectado e validação com pessoas não especialistas.
+- **B — Aceitar após o ambiente subir**
+  Valida a operação, mas não a utilidade social.
+- **C — Aceitar pela matriz teórica**
+  Dispensa a PoC e deixa um critério da tarefa sem evidência.
+
+**Resposta recomendada: A.**
+
+## 18. Alternativa caso o Metabase não passe
+
+- **A — Apache Superset como segunda opção — Recomendada**
+  Mantém forte capacidade analítica, aceitando uma curva de aprendizado maior.
+- **B — Grafana como segunda opção**
+  É adequado se a prioridade mudar para monitoramento e séries temporais.
+- **C — Encerrar o Spike sem alternativa**
+  Obriga uma nova pesquisa completa se o favorito falhar.
+
+**Resposta recomendada: A.**
+
+## 19. Atualização da documentação existente
+
+- **A — Registrar a divergência e abrir correção separada — Recomendada**
+  Mantém o Spike focado e deixa claro que o README arquitetural está desatualizado.
+- **B — Corrigir toda a documentação nesta mesma entrega**
+  Melhora o repositório, mas amplia significativamente o escopo.
+- **C — Ignorar a divergência**
+  Permite que novas pessoas continuem recebendo informações incorretas.
+
+**Resposta recomendada: A.**
+
+## 20. Resultado final esperado
+
+- **A — PoC reproduzível + evidências + ADR — Recomendada**
+  A tarefa termina com comparação, ambiente executável, painel, medições e decisão fundamentada.
+- **B — Documento conceitual**
+  Entrega conhecimento, mas não comprova viabilidade.
+- **C — Ambiente técnico sem decisão**
+  Entrega código, mas não responde qual ferramenta deve ser adotada.
+
+**Resposta recomendada: A.**
+
+Para aprovar o conjunto inteiro, responda: `Aceito todas as recomendadas`.
+
+Para alterar algo, use os códigos, por exemplo: `Aceito as recomendadas, exceto 6B e 11C`.

--- a/docs/spike/grilling.md
+++ b/docs/spike/grilling.md
@@ -1,4 +1,15 @@
-Seguindo o `grill-with-docs`, consolidei todas as decisões de uma vez. Cada item traz alternativas, explicação simples e minha recomendação.
+# Decisões do Spike de análise e visualização de dados
+
+**Status:** recomendações aceitas em 26 de agosto de 2026.
+
+Este documento preserva as alternativas consideradas durante a definição do Spike. Todas as opções marcadas como **Recomendada** foram aceitas para orientar a documentação e a futura implementação da PoC.
+
+Documentos resultantes:
+
+- [Relatório do Spike](./0001-ferramenta-analise-dados.md)
+- [ADR proposto](../adr/0001-metabase-para-analise-de-dados.md)
+
+Cada item abaixo traz alternativas, uma explicação simples e a decisão aceita.
 
 ## 1. Escopo desta entrega
 
@@ -240,6 +251,6 @@ O registro deve guardar dificuldades e tempo aproximado, sem identificar publica
 
 **Resposta recomendada: A.**
 
-Para aprovar o conjunto inteiro, responda: `Aceito todas as recomendadas`.
+## Registro da decisão
 
-Para alterar algo, use os códigos, por exemplo: `Aceito as recomendadas, exceto 6B e 11C`.
+Em 26 de agosto de 2026, todas as vinte respostas recomendadas foram aceitas. O aceite define o escopo e a hipótese de trabalho, mas não transforma a escolha do Metabase em decisão arquitetural definitiva: isso depende das evidências da PoC e dos três cenários de homologação.

--- a/docs/🗂️ Índice de Leitura - Checkin Bot.md
+++ b/docs/🗂️ Índice de Leitura - Checkin Bot.md
@@ -26,6 +26,7 @@ Para desenvolvedores que querem entender o projeto Checkin Bot, recomendamos seg
 
 10. **[Spike 0001 - Ferramenta de análise de dados](./spike/0001-ferramenta-analise-dados.md)** - Comparativo entre Metabase, Apache Superset e Grafana
 11. **[ADR 0001 - Metabase para análise dos dados](./adr/0001-metabase-para-analise-de-dados.md)** - Decisão proposta e condições para aceitação
+12. **[Plano de implantação do Metabase](./9%20-%20Plano%20de%20implantação%20do%20Metabase.md)** - Caminho planejado da PoC local até homologação e produção privadas
 
 ## Sequência por Perfil
 
@@ -52,6 +53,7 @@ Para desenvolvedores que querem entender o projeto Checkin Bot, recomendamos seg
 3. [4 - Infrastructure Layer](./4%20-%20Infrastructure%20Layer.md) - Database schema
 4. [7 - Use Cases](./7%20-%20Use%20Cases.md) - Como os dados são coletados
 5. [Spike 0001 - Ferramenta de análise de dados](./spike/0001-ferramenta-analise-dados.md) - Como os dados poderão ser visualizados
+6. [Plano de implantação do Metabase](./9%20-%20Plano%20de%20implantação%20do%20Metabase.md) - Como a PoC poderá chegar a um ambiente compartilhado
 
 ### 🚀 **Para DevOps/Deploy**
 
@@ -59,6 +61,7 @@ Para desenvolvedores que querem entender o projeto Checkin Bot, recomendamos seg
 2. [5 - Contexts](./5%20-%20Contexts.md) - Configuração da aplicação
 3. [4 - Infrastructure Layer](./4%20-%20Infrastructure%20Layer.md) - Dependências externas
 4. [8 - Sincronização Histórica](./8%20-%20Sincronização%20Histórica.md) - Rodar o backfill via CLI ou GitHub Actions
+5. [Plano de implantação do Metabase](./9%20-%20Plano%20de%20implantação%20do%20Metabase.md) - Infraestrutura, segurança, deploy e retorno planejados
 
 ## Glossário Rápido
 

--- a/docs/🗂️ Índice de Leitura - Checkin Bot.md
+++ b/docs/🗂️ Índice de Leitura - Checkin Bot.md
@@ -22,6 +22,11 @@ Para desenvolvedores que querem entender o projeto Checkin Bot, recomendamos seg
 8. **[7 - Use Cases](./7%20-%20Use%20Cases.md)** - Casos de uso e regras de negócio
 9. **[8 - Sincronização Histórica](./8%20-%20Sincronização%20Histórica.md)** - Backfill de mensagens e eventos de voz via CLI
 
+### 📊 Análise de Dados e Decisões
+
+10. **[Spike 0001 - Ferramenta de análise de dados](./spike/0001-ferramenta-analise-dados.md)** - Comparativo entre Metabase, Apache Superset e Grafana
+11. **[ADR 0001 - Metabase para análise dos dados](./adr/0001-metabase-para-analise-de-dados.md)** - Decisão proposta e condições para aceitação
+
 ## Sequência por Perfil
 
 ### 👨‍💻 **Para Desenvolvedores Iniciantes**
@@ -46,6 +51,7 @@ Para desenvolvedores que querem entender o projeto Checkin Bot, recomendamos seg
 2. [6 - Entidades Principais](./6%20-%20Entidades%20Principais.md) - Modelo de dados
 3. [4 - Infrastructure Layer](./4%20-%20Infrastructure%20Layer.md) - Database schema
 4. [7 - Use Cases](./7%20-%20Use%20Cases.md) - Como os dados são coletados
+5. [Spike 0001 - Ferramenta de análise de dados](./spike/0001-ferramenta-analise-dados.md) - Como os dados poderão ser visualizados
 
 ### 🚀 **Para DevOps/Deploy**
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,5 +6,17 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
   eslint.configs.recommended,
   tseslint.configs.recommended,
+  {
+    files: ["**/*.mjs"],
+    languageOptions: {
+      globals: {
+        console: "readonly",
+        fetch: "readonly",
+        process: "readonly",
+        setTimeout: "readonly",
+        structuredClone: "readonly",
+      },
+    },
+  },
   { ignores: ["dist/", "src/oldApp"] },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-bot",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-bot",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@prisma/client": "^6.4.1",
         "@types/express": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bot",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "type": "commonjs",
   "scripts": {


### PR DESCRIPTION
## Descrição

Este Pull Request implementa o Spike de escolha de ferramenta open source para análise e visualização dos dados do Check-In.

A entrega inclui:

- comparativo entre Metabase Open Source, Apache Superset e Grafana;
- recomendação proposta do Metabase;
- ADR com critérios técnicos e sociais para a decisão;
- profile Docker Compose `analytics`;
- dataset determinístico e simulado, fiel ao modelo do Check-In;
- views SQL agregadas e usuário MariaDB somente leitura;
- dashboard `Saúde da Comunidade` com 11 cartões e filtros por período e canal;
- contas locais para administração, curadoria e leitura;
- validação de permissões de coleção e bloqueio de escrita no banco analítico;
- atualização do índice de documentação e versionamento para `1.1.0`.

## Link da tarefa

O número da tarefa não foi informado. A especificação e o rastreamento da atividade estão registrados no [relatório do Spike](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/docs/spike/0001-ferramenta-analise-dados.md).

## Tipo de mudança

- [ ] Bugfix
- [x] Nova funcionalidade
- [ ] Refatoração
- [x] Documentação

## Como foi testado?

### Subida da PoC

```bash
docker compose --profile analytics up -d
docker compose --profile analytics logs metabase-bootstrap
```

Resultado esperado: o bootstrap termina com `"status": "ok"`, o Metabase fica disponível em [http://localhost:3001](http://localhost:3001) e o dashboard `Saúde da Comunidade` é criado automaticamente.

### Acesso local à PoC

Estas são credenciais padrão de demonstração, exclusivamente locais. Não devem ser usadas em homologação ou produção:

| Perfil | Login | Senha |
| --- | --- | --- |
| Administração | `admin@checkin.local` | `CheckinLocal123!` |
| Curadoria | `editora@checkin.local` | `CheckinLocal123!` |
| Somente leitura | `leitora@checkin.local` | `CheckinLocal123!` |

### Validações executadas

- `npm run build` — aprovado.
- `npm run lint` — aprovado.
- `npm test -- --runInBand` — 31 suítes e 275 testes aprovados.
- `docker compose --profile analytics config --quiet` — aprovado.
- `node --check analytics/metabase/bootstrap.mjs` — aprovado.
- `sh -n analytics/database/bootstrap.sh` — aprovado.
- Prettier e `git diff --check` — aprovados.
- O dashboard foi aberto no navegador, os filtros de período/canal foram aplicados e as consultas retornaram dados.
- O usuário analítico foi verificado sem permissão de escrita.
- A edição de coleção retornou sucesso para `Editoras` e `403` para `Leitoras`.

Observação: a execução padrão local de `npm test` apresentou flutuação preexistente em testes de repositório que compartilham o banco de testes; a execução serial acima passou integralmente. O CI inicia um banco novo e o comportamento fica registrado para acompanhamento separado.

## Documentação relacionada

- [README](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/README.md)
- [Índice de leitura](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/docs/%F0%9F%97%82%EF%B8%8F%20%C3%8Dndice%20de%20Leitura%20-%20Checkin%20Bot.md)
- [Decisões do Spike](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/docs/spike/grilling.md)
- [Relatório do Spike e matriz comparativa](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/docs/spike/0001-ferramenta-analise-dados.md)
- [ADR 0001 — Metabase para análise](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/docs/adr/0001-metabase-para-analise-de-dados.md)
- [Documentação de produto](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/docs/0%20-%20Documenta%C3%A7%C3%A3o%20de%20Produto.md)
- [Documentação técnica](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/docs/1%20-%20Documenta%C3%A7%C3%A3o%20t%C3%A9cnica.md)
- [Domain Layer](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/docs/2%20-%20Domain%20Layer.md)
- [Application Layer](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/docs/3%20-%20Application%20Layer.md)
- [Infrastructure Layer](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/docs/4%20-%20Infrastructure%20Layer.md)
- [Contexts](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/docs/5%20-%20Contexts.md)
- [Entidades principais](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/docs/6%20-%20Entidades%20Principais.md)
- [Use Cases](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/docs/7%20-%20Use%20Cases.md)
- [Sincronização histórica](https://github.com/Coletivo-Popular-Design-Desenvolvimento/checkin-discord-bot-v1/blob/spike/analise-ferramenta-visualizacao-dados/docs/8%20-%20Sincroniza%C3%A7%C3%A3o%20Hist%C3%B3rica.md)

## Checklist

- [x] Código segue o padrão de estilo do projeto
- [ ] Testes unitários foram adicionados
- [x] A documentação foi atualizada (se aplicável)
